### PR TITLE
test helm charts with user defined package alias

### DIFF
--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -163,6 +163,7 @@ helm:
           username: ""
           password: ""
           chartName: redis
+          packageAlias: alias-for-redis
           packageVersion: 12.2.4
           deployment:
             local: false
@@ -173,6 +174,7 @@ helm:
           username: ""
           password: ""
           chartName: minio
+          packageAlias: my-minio-alias
           packageVersion: 4.1.9
           timeWindow:
             setting: true

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -138,7 +138,7 @@ helm:
     - enable: true
       name: ui-helm
       type: helm
-      successNumber: 4 #should have at least 3 resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
+      successNumber: 4 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
       new: # used when we add new subscriptions after app creation
         - url: https://dummy/helminsecureSkipVerifyOption
           username: ""
@@ -163,6 +163,7 @@ helm:
           username: ""
           password: ""
           chartName: redis
+          packageAlias: alias-for-redis
           packageVersion: 12.2.4
           deployment:
             local: false
@@ -173,6 +174,7 @@ helm:
           username: ""
           password: ""
           chartName: minio
+          packageAlias: my-minio-alias
           packageVersion: 4.1.9
           timeWindow:
             setting: true

--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -122,6 +122,7 @@ export const createHelm = (clusterName, configs, addOperation) => {
     helmUsername: "#helmUser",
     helmPassword: "#helmPassword",
     helmChartName: "#helmChartName",
+    helmPackageAlias: "#helmPackageAlias",
     helmPackageVersion: "#helmPackageVersion",
     insecureSkipVerify: "#helmInsecureSkipVerify"
   };
@@ -152,16 +153,19 @@ export const helmTasks = (clusterName, value, css, key = 0) => {
     username,
     password,
     chartName,
+    packageAlias,
     packageVersion,
     timeWindow,
     deployment,
     insecureSkipVerifyOption
   } = value;
+  cy.log("helmTasks !!!!!!", chartName, packageAlias, value);
   const {
     helmURL,
     helmUsername,
     helmPassword,
     helmChartName,
+    helmPackageAlias,
     helmPackageVersion,
     insecureSkipVerify
   } = css;
@@ -182,6 +186,14 @@ export const helmTasks = (clusterName, value, css, key = 0) => {
     .get(helmChartName, { timeout: 20 * 1000 })
     .type(chartName)
     .blur();
+  cy.log("AAAAAAA", helmPackageAlias, packageAlias);
+  packageAlias && cy.get(helmPackageAlias, { timeout: 20 * 1000 }).clear();
+  packageAlias &&
+    cy
+      .get(helmPackageAlias, { timeout: 20 * 1000 })
+      .type(packageAlias)
+      .blur();
+
   packageVersion &&
     cy
       .get(helmPackageVersion, { timeout: 20 * 1000 })

--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -159,7 +159,6 @@ export const helmTasks = (clusterName, value, css, key = 0) => {
     deployment,
     insecureSkipVerifyOption
   } = value;
-  cy.log("helmTasks !!!!!!", chartName, packageAlias, value);
   const {
     helmURL,
     helmUsername,
@@ -186,7 +185,6 @@ export const helmTasks = (clusterName, value, css, key = 0) => {
     .get(helmChartName, { timeout: 20 * 1000 })
     .type(chartName)
     .blur();
-  cy.log("AAAAAAA", helmPackageAlias, packageAlias);
   packageAlias && cy.get(helmPackageAlias, { timeout: 20 * 1000 }).clear();
   packageAlias &&
     cy


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9666

Update e2e tests to include helm chart deployments using user input package alias, not matching the package name
Validate the resources show as deployed

