### PR TITLE
show default status for ansible run as non hook

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -294,7 +294,11 @@ export const getPulseStatusForCluster = node => {
 
 const getPulseStatusForGenericNode = node => {
   //ansible job status
-  if (_.get(node, 'type', '') === 'ansiblejob') {
+  if (
+    _.get(node, 'type', '') === 'ansiblejob' &&
+    _.get(node, 'specs.raw.hookType')
+  ) {
+    // process here only ansible hooks
     return getPulseStatusForAnsibleNode(node)
   }
   let pulse = _.get(node, specPulse, 'green')
@@ -1069,7 +1073,11 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
 
-  if (_.get(node, 'type', '') === 'ansiblejob') {
+  if (
+    _.get(node, 'type', '') === 'ansiblejob' &&
+    _.get(node, 'specs.raw.hookType')
+  ) {
+    // process here only ansible hooks
     showAnsibleJobDetails(node, details)
 
     if (!_.get(node, 'specs.raw.spec')) {
@@ -1092,7 +1100,11 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
     clusterName = R.trim(clusterName)
     let res = resourceMap[`${resourceName}-${clusterName}`]
 
-    if (_.get(node, 'type', '') !== 'ansiblejob') {
+    if (
+      _.get(node, 'type', '') !== 'ansiblejob' ||
+      !_.get(node, 'specs.raw.hookType')
+    ) {
+      // process here only regular ansible tasks
       const deployedKey = res
         ? node.type === 'namespace' ? deployedNSStr : deployedStr
         : node.type === 'namespace' ? notDeployedNSStr : notDeployedStr

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -73,6 +73,7 @@ const ansibleError = {
     "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
   specs: {
     raw: {
+      hookType: "pre-hook",
       metadata: {
         name: "bigjoblaunch",
         namespace: "default"
@@ -93,6 +94,7 @@ const ansibleError2 = {
     "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
   specs: {
     raw: {
+      hookType: "pre-hook",
       metadata: {
         name: "bigjoblaunch",
         namespace: "default"
@@ -3004,6 +3006,7 @@ describe("setResourceDeployStatus ansiblejob ", () => {
       "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
     specs: {
       raw: {
+        hookType: "pre-hook",
         metadata: {
           name: "bigjoblaunch",
           namespace: "default"
@@ -3065,6 +3068,7 @@ describe("setResourceDeployStatus ansiblejob no status", () => {
       "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
     specs: {
       raw: {
+        hookType: "pre-hook",
         metadata: {
           name: "bigjoblaunch",
           namespace: "default"


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9255

If ansible tasks are run as regular deployments, show deployment status of the ansible task
Since there is no information regarding the ansible job status in this case, we'll not show this details on the properties dialog
The anisble job details can be viewed from the ansible task YAML

<img width="684" alt="Screen Shot 2021-03-09 at 11 57 03 AM" src="https://user-images.githubusercontent.com/43010150/110541412-b790e000-80f5-11eb-987e-c4a3b366b3ce.png">
