### PR TITLE
run git api on PR only and remove placement node validation

### DIFF
--- a/tests/cypress/tests/01-create/03-git-connection-tests.js
+++ b/tests/cypress/tests/01-create/03-git-connection-tests.js
@@ -5,14 +5,24 @@ const config = JSON.parse(Cypress.env("TEST_CONFIG"));
 import { testGitApiInput } from "../../views/common";
 
 describe("Application UI: [P3][Sev3][app-lifecycle-ui] Application Creation Validate git api Test", () => {
-  it(`Verify git api can access git branches`, () => {
-    for (const type in config) {
-      const apps = config[type].data;
-      apps.forEach(data => {
-        if (data.enable && data.new && type === "git") {
-          testGitApiInput(data);
-        }
-      });
-    }
-  });
+  if (Cypress.config().baseUrl.includes("localhost")) {
+    //run this test only on PRs
+    it(`Verify git api can access git branches`, () => {
+      cy.log("Test cluster", Cypress.config().baseUrl);
+      for (const type in config) {
+        const apps = config[type].data;
+        apps.forEach(data => {
+          if (data.enable && data.new && type === "git") {
+            testGitApiInput(data);
+          }
+        });
+      }
+    });
+  } else {
+    it("Skipping git api validation test, this test is only run against localhost, PR execution", () => {
+      cy.log(
+        "Cypress.config().baseUrl should include localhost to execute this test"
+      );
+    });
+  }
 });

--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -432,16 +432,6 @@ export const validateTopology = (
     } else {
       //if opType is create, the first subscription was removed by the delete subs test, use the new config option
       validateDeployables(opType == "add" ? data.new[0] : value);
-
-      const { local, online } =
-        key == 0 && opType == "add" ? data.new[0].deployment : value.deployment;
-      cy.log(`key=${key}, type=${opType}`);
-      !local
-        ? (validatePlacementNode(name, key),
-          !online && validateClusterNode(clusterName)) //ignore online placements since the app is deployed on all online clusters here and we don't know for sure how many remote clusters the hub has
-        : cy.log(
-            "cluster and placement nodes will not be created as the application is deployed locally"
-          );
     }
   }
 
@@ -464,13 +454,6 @@ export const validateTopology = (
       .then(parseInt)
       .should("be.gte", successNumber);
   }
-};
-
-export const validateClusterNode = clusterName => {
-  cy.log(`validating the cluster... ${clusterName}`);
-  cy
-    .get(`g[type="${clusterName}"]`, { timeout: 25 * 1000 })
-    .should("be.visible");
 };
 
 export const validatePlacementNode = (name, key) => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10353

Have the Git connection api test executed only on PR 
Removed the placement node validation in app topology, it doesn't add anything to the overall deployment validation for the app. We already check the app is deployed as expected using the app table. This node validation can produce errors if the app is deployed on multiple nodes ( show all subscriptions ie ) and the cluster name we are looking for is grouped and not showing in the node label 