### PR TITLE
process helm resources

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -220,8 +220,9 @@ export const getPulseStatusForSubscription = node => {
 }
 
 export const getExistingResourceMapKey = (resourceMap, name, relatedKind) => {
-  const keys = Object.keys(resourceMap)
-
+  // bofore loop, find all items with the same type as relatedKind
+  const isSameType = item => item.indexOf(`${relatedKind.kind}-`) === 0
+  const keys = R.filter(isSameType, Object.keys(resourceMap))
   let i
   for (i = 0; i < keys.length; i++) {
     if (

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -771,6 +771,9 @@ export const getNameWithoutChartRelease = (
         //get label for release name
         foundReleaseLabel = true
         const releaseName = _.trim(splitLabelContent[1])
+        if (name === releaseName) {
+          return name //name identical with release name, no extra processing needed, exit
+        }
         name = _.replace(name, `${releaseName}-`, '')
         name = _.replace(name, releaseName, '')
 
@@ -807,9 +810,13 @@ export const getNameWithoutChartRelease = (
   if (
     !foundReleaseLabel &&
     kind !== 'helmrelease' &&
-    labelMap['app.kubernetes.io/name']
+    labelMap['app.kubernetes.io/instance']
   ) {
-    name = labelMap['app.kubernetes.io/name']
+    //if name = alias-resourceName, remove alias- from name
+    name =
+      name.indexOf(`${labelMap['app.kubernetes.io/instance']}-`) === 0
+        ? name.substring(labelMap['app.kubernetes.io/instance'].length + 1)
+        : name
   }
 
   return name

--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -163,7 +163,7 @@ helm:
           username: ""
           password: ""
           chartName: redis
-          packageAlias: alias-for-redis
+          packageAlias: redis #alias-for-redis
           packageVersion: 12.2.4
           deployment:
             local: false
@@ -174,7 +174,7 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageAlias: my-minio-alias
+          packageAlias: minio #my-minio-alias
           packageVersion: 4.1.9
           timeWindow:
             setting: true

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -163,7 +163,7 @@ helm:
           username: ""
           password: ""
           chartName: redis
-          packageAlias: alias-for-redis
+          packageAlias: redis #alias-for-redis
           packageVersion: 12.2.4
           deployment:
             local: false
@@ -174,7 +174,7 @@ helm:
           username: ""
           password: ""
           chartName: minio
-          packageAlias: my-minio-alias
+          packageAlias: minio #my-minio-alias
           packageVersion: 4.1.9
           timeWindow:
             setting: true

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -327,11 +327,12 @@ describe("getPulseStatusForSubscription no subscriptionItem.status", () => {
 
 describe("getExistingResourceMapKey", () => {
   const resourceMap = {
-    "pod-replicaset-nginx-placement-cluster1, cluster2": "test"
+    "replicaset-nginx-placement-cluster1, cluster2": "test"
   };
 
   const relatedKind = {
-    cluster: "cluster1"
+    cluster: "cluster1",
+    kind: "replicaset"
   };
 
   const relatedKindBadCluster = {
@@ -345,7 +346,7 @@ describe("getExistingResourceMapKey", () => {
         "replicaset-nginx-placement",
         relatedKind
       )
-    ).toEqual("pod-replicaset-nginx-placement-cluster1, cluster2");
+    ).toEqual("replicaset-nginx-placement-cluster1, cluster2");
   });
 
   it("should not get key from resourceMap", () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10509

Helm resources are not mapped properly to deployables if the resource name contains the name of the instance
This can happen when there are more then one resource withe the same name and type deployed by the same chart or when the deployable names don't have the resource names attached

The fix should be coupled with a change in console-api where the alias name is used instead of the package name when alias is not the same with the package. I updated the samples to deploy with the same alias until I can check in the fix in console-api

Fixed the following samples

<img width="1415" alt="Screen Shot 2021-03-18 at 2 56 05 PM" src="https://user-images.githubusercontent.com/43010150/111694087-ccf9be80-8807-11eb-8241-3f1c03d6fe69.png">



<img width="1091" alt="Screen Shot 2021-03-18 at 4 38 33 PM" src="https://user-images.githubusercontent.com/43010150/111694575-6cb74c80-8808-11eb-98fc-74b517992519.png">


With the fix

<img width="1238" alt="Screen Shot 2021-03-18 at 4 37 53 PM" src="https://user-images.githubusercontent.com/43010150/111694594-7476f100-8808-11eb-828d-bdd7ea2194eb.png">
<img width="1210" alt="Screen Shot 2021-03-18 at 3 01 45 PM" src="https://user-images.githubusercontent.com/43010150/111694607-780a7800-8808-11eb-91c9-0d764f72f70e.png">
