### PR TITLE
Update lodash for a security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17029,9 +17029,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "js-yaml": "^3.12.0",
     "js-yaml-loader": "^1.2.2",
     "loadable-components": "^1.4.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "log4js": "^6.3.0",
     "mime-types": "^2.1.18",
     "minimist": "^1.2.5",


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9610

Updated `lodash` to version `4.17.21` 