### PR TITLE
argo app - use cluster related from search to set deploy status

### DIFF
--- a/src-web/components/ApplicationTopologyModule/definitions/hcm-application-diagram.js
+++ b/src-web/components/ApplicationTopologyModule/definitions/hcm-application-diagram.js
@@ -92,7 +92,7 @@ export const processNodeData = (
       : name
 
   let podsKeyForThisNode = null
-  const clusterName = getClusterName(node.id)
+  const clusterName = getClusterName(node.id, node)
   if (type === 'subscription') {
     //don't use cluster name when grouping subscriptions
     topoResourceMap[name] = node

--- a/src-web/components/Topology/viewer/ClusterDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ClusterDetailsContainer.js
@@ -404,7 +404,7 @@ class ClusterDetailsContainer extends React.Component {
         consoleURL
       } = displayClusterList[i]
 
-      const status = displayClusterList[i].status || 'unknown'
+      const status = displayClusterList[i].status || 'offline'
       const clusterName = displayClusterList[i].name || metadata.name
       const clusterNamespace =
         displayClusterList[i]._clusterNamespace || metadata.namespace

--- a/tests/jest/components/ApplicationTopologyModule/definitions/hcm-application-diagram.test.js
+++ b/tests/jest/components/ApplicationTopologyModule/definitions/hcm-application-diagram.test.js
@@ -190,6 +190,10 @@ describe("hcm-application-diagram-tests", () => {
   it("getDiagramElements with pods container info", () => {
     const nodes = [
       {
+        id: "member--clusters--",
+        type: "cluster"
+      },
+      {
         id:
           "member--clusters--possiblereptile, braveman, sharingpenguin, relievedox",
         type: "cluster",
@@ -236,8 +240,7 @@ describe("hcm-application-diagram-tests", () => {
       },
       {
         type: "deployment",
-        id:
-          "--clusters--possiblereptile, braveman, sharingpenguin, relievedox--depl",
+        id: "--clusters---depl",
         name: "depl",
         cluster: null,
         clusterName: null,
@@ -245,9 +248,7 @@ describe("hcm-application-diagram-tests", () => {
           specs: {
             clusters: [
               {
-                metadata: {
-                  name: "possiblereptile"
-                },
+                name: "possiblereptile",
                 status: "ok"
               },
               {
@@ -368,6 +369,15 @@ describe("hcm-application-diagram-tests", () => {
           name: "mortgage-app",
           namespace: "default",
           related: [
+            {
+              kind: "cluster",
+              items: [
+                {
+                  name: "sharingpenguin",
+                  status: "ok"
+                }
+              ]
+            },
             {
               items: [
                 {
@@ -546,6 +556,21 @@ describe("hcm-application-diagram-tests", () => {
     };
     const res = [
       {
+        id: "member--clusters--",
+        specs: {
+          clusters: [
+            {
+              name: "sharingpenguin",
+              status: "ok"
+            }
+          ],
+          clustersNames: ["sharingpenguin"],
+          pulse: "green",
+          shapeType: "cluster"
+        },
+        type: "cluster"
+      },
+      {
         id:
           "member--clusters--possiblereptile, braveman, sharingpenguin, relievedox",
         specs: {
@@ -575,6 +600,12 @@ describe("hcm-application-diagram-tests", () => {
               status: "ok"
             }
           ],
+          clustersNames: [
+            "possiblereptile",
+            " braveman",
+            " sharingpenguin",
+            " relievedox"
+          ],
           pulse: "green",
           shapeType: "cluster"
         },
@@ -591,6 +622,12 @@ describe("hcm-application-diagram-tests", () => {
         name: "aa",
         namespace: "ns",
         specs: {
+          clustersNames: [
+            "possiblereptile",
+            " braveman",
+            " sharingpenguin",
+            " relievedox"
+          ],
           pulse: "red",
           shapeType: "application"
         },
@@ -599,45 +636,11 @@ describe("hcm-application-diagram-tests", () => {
       {
         cluster: null,
         clusterName: null,
-        clusters: {
-          id:
-            "member--clusters--possiblereptile, braveman, sharingpenguin, relievedox",
-          specs: {
-            clusters: [
-              {
-                metadata: {
-                  name: "possiblereptile"
-                },
-                status: "ok"
-              },
-              {
-                metadata: {
-                  name: "braveman"
-                },
-                status: "ok"
-              },
-              {
-                metadata: {
-                  name: "sharingpenguin"
-                },
-                status: "ok"
-              },
-              {
-                metadata: {
-                  name: "relievedox"
-                },
-                status: "ok"
-              }
-            ],
-            pulse: "green",
-            shapeType: "cluster"
-          },
-          type: "cluster"
-        },
-        id:
-          "--clusters--possiblereptile, braveman, sharingpenguin, relievedox--depl",
+        clusters: undefined,
+        id: "--clusters---depl",
         name: "depl",
         specs: {
+          clustersNames: ["-depl"],
           pulse: "orange",
           raw: {
             spec: {
@@ -688,6 +691,12 @@ describe("hcm-application-diagram-tests", () => {
                 status: "ok"
               }
             ],
+            clustersNames: [
+              "possiblereptile",
+              " braveman",
+              " sharingpenguin",
+              " relievedox"
+            ],
             pulse: "green",
             shapeType: "cluster"
           },
@@ -697,6 +706,12 @@ describe("hcm-application-diagram-tests", () => {
           "--clusters--possiblereptile, braveman, sharingpenguin, relievedox--depl",
         name: "depl2",
         specs: {
+          clustersNames: [
+            "possiblereptile",
+            " braveman",
+            " sharingpenguin",
+            " relievedox"
+          ],
           pulse: "orange",
           raw: {
             spec: {
@@ -747,6 +762,12 @@ describe("hcm-application-diagram-tests", () => {
                 status: "ok"
               }
             ],
+            clustersNames: [
+              "possiblereptile",
+              " braveman",
+              " sharingpenguin",
+              " relievedox"
+            ],
             pulse: "green",
             shapeType: "cluster"
           },
@@ -756,6 +777,12 @@ describe("hcm-application-diagram-tests", () => {
           "--clusters--possiblereptile, braveman, sharingpenguin, relievedox--subs",
         name: "subsname",
         specs: {
+          clustersNames: [
+            "possiblereptile",
+            " braveman",
+            " sharingpenguin",
+            " relievedox"
+          ],
           pulse: "orange",
           raw: {
             spec: {

--- a/tests/jest/components/Topology/viewer/ClusterDetailsContainer.test.js
+++ b/tests/jest/components/Topology/viewer/ClusterDetailsContainer.test.js
@@ -39,6 +39,13 @@ describe("ClusterDetailsContainer with some clusters", () => {
   const mockData = {
     clusters: [
       {
+        cpu: "12",
+        memory: "23308Mi",
+        name: "argo-fxiang-eks",
+        namespace: "argo-fxiang-eks",
+        status: "ok"
+      },
+      {
         allocatable: { cpu: "11580m", memory: "20056Mi" },
         capacity: { cpu: "12", memory: "23308Mi" },
         metadata: {

--- a/tests/jest/components/Topology/viewer/__snapshots__/ClusterDetailsContainer.test.js.snap
+++ b/tests/jest/components/Topology/viewer/__snapshots__/ClusterDetailsContainer.test.js.snap
@@ -190,6 +190,199 @@ exports[`ClusterDetailsContainer with some clusters renders as expected 1`] = `
         <span
           className="pf-c-expandable-section__toggle-text"
         >
+          argo-fxiang-eks
+        </span>
+      </button>
+      <div
+        className="pf-c-expandable-section__content"
+        hidden={true}
+      >
+        <span
+          style={
+            Object {
+              "color": "#5A6872",
+              "display": "block",
+              "fontFamily": "RedHatText",
+              "fontSize": "12px",
+              "lineHeight": "21px",
+              "textAlign": "left",
+            }
+          }
+        >
+          Namespace: undefined
+        </span>
+        <span
+          className="label sectionLabel"
+          style={
+            Object {
+              "fontSize": "1rem",
+              "paddingLeft": "1rem",
+            }
+          }
+        >
+          Details
+        </span>
+        <div
+          className="spacer"
+        />
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            Name
+            :
+             
+          </span>
+          <span
+            className="value"
+          >
+            argo-fxiang-eks
+          </span>
+        </div>
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            Namespace
+            :
+             
+          </span>
+          <span
+            className="value"
+          />
+        </div>
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            Status
+            :
+             
+          </span>
+          <span
+            className="value"
+          >
+            ok
+          </span>
+        </div>
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            CPU
+            :
+             
+          </span>
+          <span
+            className="value"
+          >
+            100
+            %
+          </span>
+        </div>
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            Memory
+            :
+             
+          </span>
+          <span
+            className="value"
+          >
+            100
+            %
+          </span>
+        </div>
+        <div
+          className="sectionContent borderLeft"
+        >
+          <span
+            className="label sectionLabel"
+          >
+            Created
+            :
+             
+          </span>
+          <span
+            className="value"
+          >
+            -
+          </span>
+        </div>
+        <div
+          className="spacer"
+        />
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "color": "#5A6872",
+          "display": "block",
+          "fontFamily": "RedHatText",
+          "fontSize": "12px",
+          "lineHeight": "21px",
+          "textAlign": "left",
+        }
+      }
+    >
+      Namespace: undefined
+    </span>
+  </div>
+  <div
+    className="clusterDetailItem"
+    style={
+      Object {
+        "borderBottom": "1px solid #D2D2D2",
+      }
+    }
+  >
+    <div
+      className="pf-c-expandable-section"
+    >
+      <button
+        aria-expanded={false}
+        className="pf-c-expandable-section__toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="pf-c-expandable-section__toggle-icon"
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
+        </span>
+        <span
+          className="pf-c-expandable-section__toggle-text"
+        >
           fxiang-eks
         </span>
       </button>

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -32,6 +32,8 @@ import {
   checkAndObjects
 } from "../../../../../../src-web/components/Topology/utils/diagram-helpers";
 
+import { topology } from "./../../../TestingData";
+
 const ansibleSuccess = {
   type: "ansiblejob",
   name: "bigjoblaunch",
@@ -1759,23 +1761,23 @@ describe("setSubscriptionDeployStatus for node type different then subscription 
 
 describe("setupResourceModel ", () => {
   it("setupResourceModel", () => {
-    expect(setupResourceModel(resourceList, resourceMap, false, false)).toEqual(
-      modelResult
-    );
+    expect(
+      setupResourceModel(resourceList, resourceMap, false, false, topology)
+    ).toEqual(modelResult);
   });
 });
 
 describe("setupResourceModel ", () => {
   it("return setupResourceModel for grouped objects", () => {
-    expect(setupResourceModel(resourceList, resourceMap, true, false)).toEqual(
-      modelResult
-    );
+    expect(
+      setupResourceModel(resourceList, resourceMap, true, false, topology)
+    ).toEqual(modelResult);
   });
 });
 
 describe("setupResourceModel undefined 1", () => {
   it("return setupResourceModel for undefined 1 ", () => {
-    expect(setupResourceModel(undefined, resourceMap, true)).toEqual(
+    expect(setupResourceModel(undefined, resourceMap, true, topology)).toEqual(
       modelResult
     );
   });
@@ -1783,7 +1785,7 @@ describe("setupResourceModel undefined 1", () => {
 
 describe("setupResourceModel undefined 2", () => {
   it("return setupResourceModel for undefined 2 ", () => {
-    expect(setupResourceModel(resourceList, undefined, true)).toEqual(
+    expect(setupResourceModel(resourceList, undefined, true, topology)).toEqual(
       undefined
     );
   });


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9035

Update status logic
- get related clusters from search
- for backward compatibility, if topology nodes returned by search have the list of clusters in node.id, use that info to build status , otherwise, use search clusters
- will fix in a separate task the argo app cluster number on the cluster node, it shows 0 now

<img width="859" alt="Screen Shot 2021-03-25 at 5 47 34 PM" src="https://user-images.githubusercontent.com/43010150/112589376-58aab680-8dd7-11eb-96d3-7376e893d6eb.png">
<img width="1401" alt="Screen Shot 2021-03-25 at 1 50 35 PM" src="https://user-images.githubusercontent.com/43010150/112589455-80018380-8dd7-11eb-8c93-8f143478886c.png">
<img width="1097" alt="Screen Shot 2021-03-26 at 8 46 00 AM" src="https://user-images.githubusercontent.com/43010150/112633492-cb378880-8e0f-11eb-9915-5c7fafc73ee1.png">
<img width="1047" alt="Screen Shot 2021-03-26 at 8 46 22 AM" src="https://user-images.githubusercontent.com/43010150/112633506-cd99e280-8e0f-11eb-850d-adaa1a1433e3.png">
