### PR TITLE
Add Argo app count to app node

### DIFF
--- a/src-web/components/Topology/viewer/constants.js
+++ b/src-web/components/Topology/viewer/constants.js
@@ -79,6 +79,16 @@ export const ClusterCountIcon = {
   dy: 0
 }
 
+// icon for containing the argo app count
+export const ArgoAppCountIcon = {
+  icon: 'clusterCount',
+  classType: 'argoAppCount',
+  width: 22,
+  height: 18,
+  dx: 26,
+  dy: 0
+}
+
 //if controller contains a pod
 export const PodIcon = {
   icon: 'circle',

--- a/src-web/components/Topology/viewer/defaults/status.js
+++ b/src-web/components/Topology/viewer/defaults/status.js
@@ -10,7 +10,11 @@
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
 
-import { StatusIcon, ClusterCountIcon } from '../constants.js'
+import {
+  StatusIcon,
+  ClusterCountIcon,
+  ArgoAppCountIcon
+} from '../constants.js'
 import msgs from '../../../../../nls/platform.properties'
 import _ from 'lodash'
 
@@ -152,15 +156,22 @@ const getStd = array => {
 export const updateNodeIcons = nodes => {
   nodes.forEach(node => {
     const nodeIcons = {}
-    const { type, layout = {} } = node
+    const { type, layout = {}, specs = {} } = node
 
     // status icon
     let nodeStatus = ''
     let disabled = false
 
+    if (
+      type === 'application' &&
+      (specs.raw && specs.raw.apiVersion.indexOf('argoproj.io') > -1)
+    ) {
+      layout.argoAppCountIcon = ArgoAppCountIcon
+      layout.argoAppCount = specs.relatedApps.length
+    }
+
     if (type === 'cluster') {
       // determine icon
-      const { specs = {} } = node
       if (specs.clusterStatus) {
         const {
           hasWarning,

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -61,7 +61,7 @@ git:
             local: true
             online: false
             matchingLabel: false
-    - enable: true
+    - enable: false
       name: ui-git-ansible
       type: git
       successNumber: 3 #success number includes the two ansible hooks and the ansible regular task

--- a/tests/jest/components/Topology/viewer/defaults/status.test.js
+++ b/tests/jest/components/Topology/viewer/defaults/status.test.js
@@ -31,8 +31,6 @@ const applicationNodes = [
       nodeStatus: "",
       search: "",
       title: "",
-      type: "application",
-      uid: "application--nginx-app-3",
       x: 1.5,
       y: 1.5
     },
@@ -42,6 +40,49 @@ const applicationNodes = [
       isDesign: true,
       row: 0,
       pulse: "orange"
+    },
+    topology: null,
+    type: "application",
+    uid: "application--nginx-app-3",
+    __typename: "Resource"
+  }
+];
+
+const argoApplicationNodes = [
+  {
+    cluster: null,
+    clusterName: null,
+    id: "application--nginx-app-3",
+    labels: null,
+    layout: {
+      uid: "application--nginx-app-3",
+      type: "application",
+      label: "nginx-app-3",
+      compactLabel: "nginx-app-3",
+      nodeIcons: {
+        classType: "failure",
+        dx: 16,
+        dy: -16,
+        height: 16,
+        icon: "failure",
+        width: 16
+      },
+      nodeStatus: "",
+      search: "",
+      title: "",
+      x: 1.5,
+      y: 1.5
+    },
+    name: "nginx-app-3",
+    namespace: "ns-sub-1",
+    specs: {
+      isDesign: true,
+      row: 0,
+      pulse: "orange",
+      raw: {
+        apiVersion: "argoproj.io/v1alpha1"
+      },
+      relatedApps: []
     },
     topology: null,
     type: "application",
@@ -659,5 +700,11 @@ describe("updateNodeIcons application nodes red", () => {
   ];
   it("should update application node", () => {
     expect(updateNodeIcons(applicationNodesRed, locale)).toEqual(undefined);
+  });
+});
+
+describe("updateNodeIcons test Argo application", () => {
+  it("should update the Argo application node", () => {
+    expect(updateNodeIcons(argoApplicationNodes, locale)).toEqual(undefined);
   });
 });


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9035

Added the Argo app count to the app node:
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/38960034/112677681-719b8200-8e40-11eb-9232-b3b806367731.png">

The count will only appear for Argo apps. ACM apps will not have this.