### PR TITLE
 show cluster info from search and target server - argo

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -314,9 +314,11 @@ export const fetchResource = (resourceType, namespace, name, querySettings) => {
         }
         const searchResult = lodash.get(response, 'data.searchResult', [])
         if (
-          searchResult.length === 0 ||
-          lodash.get(searchResult[0], 'items', []).length === 0
+          !querySettings.isArgoApp &&
+          (searchResult.length === 0 ||
+            lodash.get(searchResult[0], 'items', []).length === 0)
         ) {
+          //ignore this for argo apps, if we got to this point the app exists
           //app not found
           const err = {
             err: msgs.get(

--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -11,7 +11,7 @@
 import lodash from 'lodash'
 
 import * as Actions from './index'
-import { RESOURCE_TYPES, LOCAL_HUB_NAME } from '../../lib/shared/constants'
+import { RESOURCE_TYPES } from '../../lib/shared/constants'
 import apolloClient from '../../lib/client/apollo-client'
 import { fetchResource } from './common'
 import { nodeMustHavePods } from '../components/Topology/utils/diagram-helpers-utils'
@@ -223,16 +223,14 @@ const fetchApplicationRelatedObjects = (
 //try to find the name of the remote clusters using the server path
 const findMatchingCluster = argoApp => {
   const serverApi = lodash.get(argoApp, 'destinationServer')
-
-  let clusterName
   if (
     (serverApi && serverApi === 'https://kubernetes.default.svc') ||
     lodash.get(argoApp, 'destinationName', '') === 'in-cluster'
   ) {
     // TODO: replace this with the cluster mapping once we have that
-    clusterName = argoApp.cluster //target is the same as the argo app cluster
+    return argoApp.cluster //target is the same as the argo app cluster
   }
-  return clusterName
+  return serverApi
 }
 
 //get all argo applications using the same source repo as the selected app
@@ -297,13 +295,6 @@ const fetchArgoApplications = (
         //desired deployment state
         lodash.set(firstNode, 'specs.clusterNames', appData.clusterInfo)
         lodash.set(topoClusterNode, 'specs.appClusters', appData.clusterInfo)
-        const isLocal = appData.clusterInfo.indexOf(LOCAL_HUB_NAME) !== -1
-        lodash.set(firstNode, 'specs.allClusters', {
-          isLocal,
-          remoteCount: isLocal
-            ? appData.clusterInfo.length - 1
-            : appData.clusterInfo.length
-        })
       }
       fetchApplicationRelatedObjects(
         dispatch,

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -77,9 +77,16 @@ export const nodeMustHavePods = node => {
   return false
 }
 
-export const getClusterName = (nodeId, node) => {
+export const getClusterName = (nodeId, node, findAll) => {
   if (node && _.get(node, 'clusters.id', '') === 'member--clusters--') {
     //cluster info is not set on the node id, get it from here
+    if (findAll) {
+      //get all cluster names as set by argo target, ignore deplaybale status
+      return _.union(
+        _.get(node, 'specs.clustersNames', []),
+        _.get(node, 'clusters.specs.appClusters', [])
+      ).join(',')
+    }
     return _.get(node, 'specs.clustersNames', []).join(',')
   }
 

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -315,7 +315,7 @@ const getPulseStatusForGenericNode = node => {
       : name
 
   const resourceMap = _.get(node, `specs.${node.type}Model`)
-  const clusterNames = R.split(',', getClusterName(node.id, node))
+  const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
   if (!resourceMap || onlineClusters.length === 0) {
@@ -414,7 +414,7 @@ export const getPulseForNodeWithPodStatus = node => {
   }
 
   const resourceName = _.get(node, metadataName, '')
-  const clusterNames = R.split(',', getClusterName(node.id, node))
+  const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
 
@@ -1124,7 +1124,7 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
   const resourceName =
     !isDeployable && channel.length > 0 ? `${channel}-${name}` : name
 
-  const clusterNames = R.split(',', getClusterName(node.id, node))
+  const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const resourceMap = _.get(node, `specs.${node.type}Model`, {})
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
@@ -1170,7 +1170,6 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
       labelKey: 'resource.deploy.statuses'
     })
   }
-
   clusterNames.forEach(clusterName => {
     details.push({
       type: 'spacer'
@@ -1286,7 +1285,7 @@ export const setPodDeployStatus = (
   const podStatusModel = _.get(updatedNode, 'podStatusMap', {})
   const podDataPerCluster = {} //pod details list for each cluster name
 
-  const clusterNames = R.split(',', getClusterName(node.id, node))
+  const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
 

--- a/src-web/components/Topology/viewer/ClusterDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ClusterDetailsContainer.js
@@ -404,7 +404,7 @@ class ClusterDetailsContainer extends React.Component {
         consoleURL
       } = displayClusterList[i]
 
-      const status = displayClusterList[i].status || 'offline'
+      const status = displayClusterList[i].status || 'unknown'
       const clusterName = displayClusterList[i].name || metadata.name
       const clusterNamespace =
         displayClusterList[i]._clusterNamespace || metadata.namespace

--- a/src-web/components/Topology/viewer/DetailsView.js
+++ b/src-web/components/Topology/viewer/DetailsView.js
@@ -296,6 +296,8 @@ class DetailsView extends React.Component {
       <div className="sectionContent" key={Math.random()}>
         <ClusterDetailsContainer
           clusterList={comboboxdata.clusterList}
+          sortedClusterNames={comboboxdata.sortedClusterNames}
+          searchClusters={comboboxdata.searchClusters}
           clusterID={comboboxdata.clusterID}
           locale={locale}
           clusterDetailsContainerControl={clusterDetailsContainerControl}

--- a/src-web/components/Topology/viewer/defaults/status.js
+++ b/src-web/components/Topology/viewer/defaults/status.js
@@ -180,8 +180,12 @@ export const updateNodeIcons = nodes => {
         nodeStatus = status
         disabled = isDisabled
       }
+      const clustersCount =
+        _.get(specs, 'clusters', []).length ||
+        _.get(specs, 'appClusters', []).length ||
+        _.get(specs, 'clustersNames', []).length
       layout.clusterCountIcon = ClusterCountIcon
-      layout.clusterCount = specs.clusters.length
+      layout.clusterCount = clustersCount
     }
 
     const pulse = _.get(node, 'specs.pulse', '')

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -61,7 +61,8 @@ git:
             local: true
             online: false
             matchingLabel: false
-      - name: ui-git-ansible
+    - enable: false
+      name: ui-git-ansible
       type: git
       successNumber: 3 #success number includes the two ansible hooks and the ansible regular task
       config:

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -61,7 +61,7 @@ git:
             local: true
             online: false
             matchingLabel: false
-    - enable: true
+    - enable: false
       name: ui-git-ansible
       type: git
       successNumber: 3 #success number includes the two ansible hooks and the ansible regular task

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -61,8 +61,7 @@ git:
             local: true
             online: false
             matchingLabel: false
-    - enable: false
-      name: ui-git-ansible
+      - name: ui-git-ansible
       type: git
       successNumber: 3 #success number includes the two ansible hooks and the ansible regular task
       config:


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9035

A few fixes for clusters:
- show cluster nb on cluster node 
- when argo apps are not deployed on target servers, show the not deployed info
- fixed the cluster status on card - matches the nb of clusters the app has been deployed to


<img width="1349" alt="Screen Shot 2021-03-26 at 4 43 00 PM" src="https://user-images.githubusercontent.com/43010150/112691767-2f7c3b80-8e54-11eb-8ad1-020df9c97f87.png">

<img width="1321" alt="Screen Shot 2021-03-26 at 4 43 17 PM" src="https://user-images.githubusercontent.com/43010150/112691783-3440ef80-8e54-11eb-915b-bb8a243f4ccb.png">

<img width="1355" alt="Screen Shot 2021-03-26 at 4 43 45 PM" src="https://user-images.githubusercontent.com/43010150/112691805-3b67fd80-8e54-11eb-83b0-6d3b09ce8dae.png">


<img width="1103" alt="Screen Shot 2021-03-26 at 4 44 05 PM" src="https://user-images.githubusercontent.com/43010150/112691826-4327a200-8e54-11eb-8d4d-82ea8b65ac5b.png">

<img width="1280" alt="Screen Shot 2021-03-26 at 4 44 17 PM" src="https://user-images.githubusercontent.com/43010150/112691845-4c187380-8e54-11eb-9cc4-0423185ea9df.png">

<img width="817" alt="Screen Shot 2021-03-26 at 5 30 27 PM" src="https://user-images.githubusercontent.com/43010150/112695395-5a698e00-8e5a-11eb-8628-1f403fc21c1f.png">
