### PR TITLE
show error on open argo editor when no route

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -297,6 +297,9 @@ export const fetchResource = (resourceType, namespace, name, querySettings) => {
         //ask only for these type of resources
         query.relatedKinds = querySettings.relatedKinds
       } else {
+        //filter out any argo app with the same name and ns, we are looking here for acm apps
+        query.filters.push({ property: 'apigroup', values: ['!argoproj.io'] })
+
         //get related resources for the application, but only this subset
         query.relatedKinds = querySettings.relatedKinds
       }

--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -148,12 +148,12 @@ export const openArgoCDEditor = (cluster, namespace, name) => {
           const routes = lodash.get(searchResult[0], 'items', [])
           const route = routes.length > 0 ? routes[0] : null
           if (!route) {
-            return {
-              error: msgs.get('resource.argo.app.route.err', [
-                namespace,
-                cluster
-              ])
-            }
+            const errMsg = msgs.get('resource.argo.app.route.err', [
+              namespace,
+              cluster
+            ])
+            window.alert(errMsg)
+            return
           } else {
             //get route object info
             const routeRequest = {


### PR DESCRIPTION
Changes:
- fix the open argo editor; show an error message when no route foud
- when trying to open an app, if no apiVersion query param is set, the console-api looks for acm apps only but search returns all apps with that name and ns; as a result there is no error the app was not found; fixed that and ask search to look only for acm ( non argo apps )
<img width="967" alt="Screen Shot 2021-03-29 at 9 28 09 AM" src="https://user-images.githubusercontent.com/43010150/112845382-ce7e7e80-9072-11eb-9584-38f4845fe26d.png">
<img width="848" alt="Screen Shot 2021-03-29 at 9 25 39 AM" src="https://user-images.githubusercontent.com/43010150/112845418-d6d6b980-9072-11eb-8bac-6cdb0ad2762c.png">
