### PR TITLE
Point users to look at YAML for errors

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -375,6 +375,7 @@ refresh.interval.seconds = Refresh every {0}s
 resource.application = Application
 resource.application.error = Error
 resource.application.error.msg=This application has no matched subscription. Make sure the subscription match selector spec.selector.matchExpressions exists and matches a Subscription resource created in the {0} namespace.
+resource.argo.application.error.msg=Use the View Resource YAML link above to view the ArgoCD application details. Look for any error messages under the status section to debug.
 resource.applications = Applications
 resource.argo.app.cluster=Created on
 resource.argo.app.route.err = No Argo CD route found for namespace {0} on cluster {1}

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -322,6 +322,20 @@ export const namespaceMatchTargetServer = (
 }
 
 export const setArgoApplicationDeployStatus = (node, details) => {
+  // show error if app is not healthy
+  const appHealth = _.get(node, 'specs.raw.status.health.status')
+  const appStatusConditions = _.get(node, 'specs.raw.status.conditions')
+
+  if (
+    (appHealth === 'Unknown' || appHealth === 'Error') &&
+    appStatusConditions
+  ) {
+    details.push({
+      labelKey: 'resource.rule.clusters.error.label',
+      value: msgs.get('resource.argo.application.error.msg'),
+      status: failureStatus
+    })
+  }
   const relatedArgoApps = _.get(node, 'specs.relatedApps', [])
 
   // related Argo apps

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -331,6 +331,7 @@
   "resource.application": "Application",
   "resource.application.error": "Error",
   "resource.application.error.msg": "This application has no matched subscription. Make sure the subscription match selector spec.selector.matchExpressions exists and matches a Subscription resource created in the {0} namespace.",
+  "resource.argo.application.error.msg": "Use the View Resource YAML link above to view the ArgoCD application details. Look for any error messages under the status section to debug.",
   "resource.applications": "Applications",
   "resource.argo.app.cluster": "Created on",
   "resource.argo.app.route.err": "No Argo CD route found for namespace {0} on cluster {1}",


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10943

- Added error msg to the Argo app detail prop dialog

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/38960034/113063288-0ffe4f00-9183-11eb-9fca-2df159f3a321.png">

For related apps, since there's no YAML link I will work on their error status and add the YAML link in https://github.com/open-cluster-management/backlog/issues/10816