### PR TITLE
show resources grouped by namespace

### DIFF
--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -259,6 +259,7 @@ const fetchArgoApplications = (
         const targetNS = []
         const targetClusters = []
         const argoAppsLabelNames = []
+        const targetNSForClusters = {} //keep track of what namespaces each cluster must deploy on
         allApps.forEach(argoApp => {
           //get destination and clusters information
           argoAppsLabelNames.push(`app.kubernetes.io/instance=${argoApp.name}`)
@@ -271,8 +272,22 @@ const fetchArgoApplications = (
             'destinationCluster',
             argoServerNameDest || argoApp.destinationServer
           )
-          argoServerNameDest && targetClusters.push(argoServerNameDest) //add the name as is
-          argoServerDest && targetClusters.push(argoServerDest)
+          const targetClusterName = argoServerNameDest
+            ? argoServerNameDest
+            : argoServerDest ? argoServerDest : null
+          if (targetClusterName) {
+            targetClusters.push(targetClusterName)
+            //add namespace to target list
+            if (!targetNSForClusters[targetClusterName]) {
+              targetNSForClusters[targetClusterName] = []
+            }
+            if (
+              argoNS &&
+              !lodash.includes(targetNSForClusters[targetClusterName], argoNS)
+            ) {
+              targetNSForClusters[targetClusterName].push(argoNS)
+            }
+          }
         })
         appData.targetNamespaces = lodash.uniq(targetNS)
         appData.clusterInfo = lodash.uniq(targetClusters)
@@ -291,6 +306,11 @@ const fetchArgoApplications = (
         //desired deployment state
         lodash.set(firstNode, 'specs.clusterNames', appData.clusterInfo)
         lodash.set(topoClusterNode, 'specs.appClusters', appData.clusterInfo)
+        lodash.set(
+          topoClusterNode,
+          'specs.targetNamespaces',
+          targetNSForClusters
+        )
       }
       fetchApplicationRelatedObjects(
         dispatch,

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -292,16 +292,16 @@ export const syncControllerRevisionPodStatusMap = resourceMap => {
 
 //for items with pods and not getting ready or available state, default those values to the current state
 //this is a workaround for defect 8935, search doesn't return ready and available state for resources such as StatefulSets
-export const fixMissingStateOptions = item => {
-  if (item) {
+export const fixMissingStateOptions = items => {
+  items.forEach(item => {
     if (_.get(item, 'available') === undefined) {
       item.available = item.current //default to current state
     }
     if (_.get(item, 'ready') === undefined) {
       item.ready = item.current //default to current state
     }
-  }
-  return item
+  })
+  return items
 }
 
 //last attempt to match the resource namespace with the server target namespace ( argo )

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -214,24 +214,22 @@ export const getPulseStatusForSubscription = node => {
     return pulse
   }
   let isPlaced = false
-  Object.values(resourceMap).forEach(subscriptionItemArray => {
-    subscriptionItemArray.forEach(subscriptionItem => {
-      if (subscriptionItem.status) {
-        if (R.contains('Failed', subscriptionItem.status)) {
-          pulse = 'red'
-        }
-        if (subscriptionItem.status === 'Subscribed') {
-          isPlaced = true // at least one cluster placed
-        }
-        if (
-          subscriptionItem.status !== 'Subscribed' &&
-          subscriptionItem.status !== 'Propagated' &&
-          pulse !== 'red'
-        ) {
-          pulse = 'yellow' // anything but failed or subscribed
-        }
+  _.flatten(Object.values(resourceMap)).forEach(subscriptionItem => {
+    if (subscriptionItem.status) {
+      if (R.contains('Failed', subscriptionItem.status)) {
+        pulse = 'red'
       }
-    })
+      if (subscriptionItem.status === 'Subscribed') {
+        isPlaced = true // at least one cluster placed
+      }
+      if (
+        subscriptionItem.status !== 'Subscribed' &&
+        subscriptionItem.status !== 'Propagated' &&
+        pulse !== 'red'
+      ) {
+        pulse = 'yellow' // anything but failed or subscribed
+      }
+    }
   })
   if (pulse === 'green' && !isPlaced) {
     pulse = 'yellow' // set to yellow if not placed

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -145,18 +145,22 @@ export const getActiveFilterCodes = resourceStatuses => {
 
 export const filterSubscriptionObject = (resourceMap, activeFilterCodes) => {
   const filteredObject = {}
-  Object.entries(resourceMap).forEach(([key, value]) => {
-    if (value.status === 'Subscribed' && activeFilterCodes.has(checkmarkCode)) {
-      filteredObject[key] = value
-    }
-    if (value.status === 'Propagated' && activeFilterCodes.has(warningCode)) {
-      filteredObject[key] = value
-    }
-    if (value.status === 'Fail' && activeFilterCodes.has(failureCode)) {
-      filteredObject[key] = value
-    }
+  Object.entries(resourceMap).forEach(([key, values]) => {
+    values.forEach(value => {
+      if (
+        value.status === 'Subscribed' &&
+        activeFilterCodes.has(checkmarkCode)
+      ) {
+        filteredObject[key] = value
+      }
+      if (value.status === 'Propagated' && activeFilterCodes.has(warningCode)) {
+        filteredObject[key] = value
+      }
+      if (value.status === 'Fail' && activeFilterCodes.has(failureCode)) {
+        filteredObject[key] = value
+      }
+    })
   })
-
   return filteredObject
 }
 
@@ -209,25 +213,25 @@ export const getPulseStatusForSubscription = node => {
     pulse = 'orange' //resource not available
     return pulse
   }
-
   let isPlaced = false
-  Object.values(resourceMap).forEach(subscriptionItem => {
-    if (subscriptionItem.status) {
-      if (R.contains('Failed', subscriptionItem.status)) {
-        pulse = 'red'
+  Object.values(resourceMap).forEach(subscriptionItemArray => {
+    subscriptionItemArray.forEach(subscriptionItem => {
+      if (subscriptionItem.status) {
+        if (R.contains('Failed', subscriptionItem.status)) {
+          pulse = 'red'
+        }
+        if (subscriptionItem.status === 'Subscribed') {
+          isPlaced = true // at least one cluster placed
+        }
+        if (
+          subscriptionItem.status !== 'Subscribed' &&
+          subscriptionItem.status !== 'Propagated' &&
+          pulse !== 'red'
+        ) {
+          pulse = 'yellow' // anything but failed or subscribed
+        }
       }
-      if (subscriptionItem.status === 'Subscribed') {
-        isPlaced = true // at least one cluster placed
-      }
-
-      if (
-        subscriptionItem.status !== 'Subscribed' &&
-        subscriptionItem.status !== 'Propagated' &&
-        pulse !== 'red'
-      ) {
-        pulse = 'yellow' // anything but failed or subscribed
-      }
-    }
+    })
   })
   if (pulse === 'green' && !isPlaced) {
     pulse = 'yellow' // set to yellow if not placed

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -748,7 +748,7 @@ export const createResourceSearchLink = node => {
     const kindModel = _.get(node, `specs.${nodeType}Model`, {})
     let computedNameList = []
     let computedNSList = []
-    Object.values(kindModel).forEach(item => {
+    _.flatten(Object.values(kindModel)).forEach(item => {
       computedNameList = R.union(computedNameList, [item.name])
       computedNSList = R.union(computedNSList, [item.namespace])
     })

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -308,6 +308,7 @@ const getPulseStatusForGenericNode = node => {
     return pulse //no need to check anything else, return red
   }
   const name = _.get(node, metadataName, '')
+  const namespace = _.get(node, metadataNamespace, '')
   const channel = _.get(node, 'specs.raw.spec.channel', '')
   const resourceName =
     !isDeployableResource(node) && channel.length > 0
@@ -327,16 +328,29 @@ const getPulseStatusForGenericNode = node => {
     pulse = 'yellow'
     return pulse
   }
-
+  // list of target namespaces per cluster
+  const targetNamespaces = _.get(node, 'clusters.specs.targetNamespaces', {})
   //go through all clusters to make sure all pods are counted, even if they are not deployed there
   clusterNames.forEach(clusterName => {
     clusterName = R.trim(clusterName)
-    const resourceItem = resourceMap[`${resourceName}-${clusterName}`]
-
-    if (!resourceItem) {
-      // resource not created on a cluster
-      pulse = 'yellow'
-    }
+    const resourcesForCluster =
+      resourceMap[`${resourceName}-${clusterName}`] || []
+    //get target cluster namespaces
+    const targetNSList = targetNamespaces[clusterName] ||
+      (resourcesForCluster.length > 0 &&
+        _.uniq(_.map(resourcesForCluster, 'namespace'))) || [namespace]
+    targetNSList.forEach(targetNS => {
+      if (
+        !_.find(
+          resourcesForCluster,
+          obj => _.get(obj, 'namespace', '') === targetNS
+        )
+      ) {
+        // resource not created on this cluster for the required target namespace
+        pulse = 'yellow'
+        return pulse
+      }
+    })
   })
 
   return pulse
@@ -408,12 +422,13 @@ export const getPulseForNodeWithPodStatus = node => {
     resourceMap &&
     Object.keys(resourceMap).length > 0
   ) {
-    desired = resourceMap[Object.keys(resourceMap)[0]].desired
-      ? resourceMap[Object.keys(resourceMap)[0]].desired
+    desired = resourceMap[Object.keys(resourceMap)[0]][0].desired
+      ? resourceMap[Object.keys(resourceMap)[0]][0].desired
       : 'NA'
   }
 
   const resourceName = _.get(node, metadataName, '')
+  const namespace = _.get(node, metadataNamespace, '')
   const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
@@ -425,71 +440,94 @@ export const getPulseForNodeWithPodStatus = node => {
 
   //must have pods, set the pods status here
   const podStatusMap = {}
-  const podList = _.get(node, 'specs.podModel', {})
+  const podList = _.get(node, 'specs.podModel', [])
 
+  // list of target namespaces per cluster
+  const targetNamespaces = _.get(node, 'clusters.specs.targetNamespaces', {})
   //go through all clusters to make sure all pods are counted, even if they are not deployed there
   clusterNames.forEach(clusterName => {
     clusterName = R.trim(clusterName)
-    const resourceItem = fixMissingStateOptions(
-      resourceMap[`${resourceName}-${clusterName}`]
+    const resourceItems = fixMissingStateOptions(
+      resourceMap[`${resourceName}-${clusterName}`] || []
     )
 
-    const processItem = Object.keys(podList).length === 0 && resourceItem
-
-    if (resourceItem && resourceItem.kind === 'daemonset') {
-      desired = resourceItem.desired
-    }
-
-    let podsReady = 0
-    let podsUnavailable = 0
-    //find pods status and pulse from pods model, if available
-    Object.values(podList).forEach(podItem => {
-      podsUnavailable =
-        podsUnavailable + getPodState(podItem, clusterName, podErrorStates) //podsUnavailable + 1
-      podsReady =
-        podsReady + getPodState(podItem, clusterName, podSuccessStates)
-    })
-
-    podStatusMap[clusterName] = {
-      available: 0,
-      current: 0,
-      desired: desired,
-      ready: podsReady,
-      unavailable: podsUnavailable
-    }
-
-    pulse = getPulseForData(pulse, podsReady, desired, podsUnavailable)
-    if (processItem) {
-      //no pods linked to the resource, check if we have enough information on the actual resource
-      podStatusMap[clusterName] = {
-        available: resourceItem.available || 0,
-        current: resourceItem.current || 0,
-        desired: resourceItem.desired || 0,
-        ready: resourceItem.ready || 0
-      }
-
-      pulse = getPulseForData(
-        pulse,
-        resourceItem.available ? resourceItem.available : 0,
-        resourceItem.desired,
-        0
+    //get cluster target namespaces
+    const targetNSList = targetNamespaces[clusterName] ||
+      (resourceItems.length > 0 &&
+        _.uniq(_.map(resourceItems, 'namespace'))) || [namespace]
+    targetNSList.forEach(targetNS => {
+      const resourceItemsForNS = _.filter(
+        resourceItems,
+        obj => _.get(obj, 'namespace', '') === targetNS
       )
-    }
-    // assign a number to each pulse with lowest number being most critical
-    if (pulse === 'green') {
-      pulseArr.push(3)
-    } else if (pulse === 'yellow') {
-      pulseArr.push(2)
-    } else if (pulse === 'orange') {
-      pulseArr.push(1)
-    } else if (pulse === 'red') {
-      pulseArr.push(0)
-    }
+
+      const podObjects = _.flatten(Object.values(podList))
+      resourceItemsForNS.forEach(resourceItem => {
+        //process item if there are no pods in the same ns - cluster as resource item
+        const processItem =
+          resourceItem &&
+          _.filter(
+            Object.values(podObjects),
+            obj =>
+              _.get(obj, 'namespace', '') === targetNS &&
+              _.get(obj, 'cluster', '') === clusterName
+          ).length === 0
+        if (resourceItem && resourceItem.kind === 'daemonset') {
+          desired = resourceItem.desired
+        }
+
+        let podsReady = 0
+        let podsUnavailable = 0
+        //find pods status and pulse from pods model, if available
+        Object.values(podObjects).forEach(podItem => {
+          podsUnavailable =
+            podsUnavailable + getPodState(podItem, clusterName, podErrorStates) //podsUnavailable + 1
+          podsReady =
+            podsReady + getPodState(podItem, clusterName, podSuccessStates)
+        })
+
+        podStatusMap[`${clusterName}-${targetNS}`] = {
+          available: 0,
+          current: 0,
+          desired: desired,
+          ready: podsReady,
+          unavailable: podsUnavailable
+        }
+
+        pulse = getPulseForData(pulse, podsReady, desired, podsUnavailable)
+        if (processItem) {
+          //no pods linked to the resource, check if we have enough information on the actual resource
+          podStatusMap[`${clusterName}-${targetNS}`] = {
+            available: resourceItem.available || 0,
+            current: resourceItem.current || 0,
+            desired: resourceItem.desired || 0,
+            ready: resourceItem.ready || 0
+          }
+
+          pulse = getPulseForData(
+            pulse,
+            resourceItem.available ? resourceItem.available : 0,
+            resourceItem.desired,
+            0
+          )
+        }
+        // assign a number to each pulse with lowest number being most critical
+        if (pulse === 'green') {
+          pulseArr.push(3)
+        } else if (pulse === 'yellow') {
+          pulseArr.push(2)
+        } else if (pulse === 'orange') {
+          pulseArr.push(1)
+        } else if (pulse === 'red') {
+          pulseArr.push(0)
+        }
+      })
+    })
   })
 
   // set node icon to the most critical status
   const minPulse = Math.min.apply(null, pulseArr)
-  pulse = pulseValueArr[minPulse]
+  pulse = pulseValueArr[minPulse] || pulseValueArr[2] //show orange is no pods
   _.set(node, 'podStatusMap', podStatusMap)
 
   if (onlineClusters.length < clusterNames.length) {
@@ -920,7 +958,10 @@ const addResourceToModel = (
   nameWithoutChartRelease
 ) => {
   const kindModel = _.get(resourceMapObject, `specs.${kind}Model`, {})
-  kindModel[`${nameWithoutChartRelease}-${relatedKind.cluster}`] = relatedKind
+  const kindList =
+    kindModel[`${nameWithoutChartRelease}-${relatedKind.cluster}`] || []
+  kindList.push(relatedKind)
+  kindModel[`${nameWithoutChartRelease}-${relatedKind.cluster}`] = kindList
   _.set(resourceMapObject, `specs.${kind}Model`, kindModel)
 }
 
@@ -1120,6 +1161,7 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
     return details
   }
   const name = _.get(node, metadataName, '')
+  const namespace = _.get(node, metadataNamespace, '')
   const channel = _.get(node, 'specs.raw.spec.channel', '')
   const resourceName =
     !isDeployable && channel.length > 0 ? `${channel}-${name}` : name
@@ -1128,6 +1170,8 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
   const resourceMap = _.get(node, `specs.${node.type}Model`, {})
   const clusterObjs = _.get(node, clusterObjsPath, [])
   const onlineClusters = getOnlineClusters(clusterNames, clusterObjs)
+  // list of target namespaces per cluster
+  const targetNamespaces = _.get(node, 'clusters.specs.targetNamespaces', {})
 
   if (
     _.get(node, 'type', '') === 'ansiblejob' &&
@@ -1184,72 +1228,86 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
       // offline cluster, skip
       return
     }
-    let res = resourceMap[`${resourceName}-${clusterName}`]
+    details.push({
+      labelValue: msgs.get('topology.filter.category.clustername'),
+      value: clusterName
+    })
+    const resourcesForCluster =
+      resourceMap[`${resourceName}-${clusterName}`] || []
+    //get cluster target namespaces
+    const targetNSList = targetNamespaces[clusterName] ||
+      (resourcesForCluster.length > 0 &&
+        _.uniq(_.map(resourcesForCluster, 'namespace'))) || [namespace]
+    targetNSList.forEach(targetNS => {
+      let res = _.find(
+        resourcesForCluster,
+        obj => _.get(obj, 'namespace', '') === targetNS
+      )
+      if (
+        _.get(node, 'type', '') !== 'ansiblejob' ||
+        !_.get(node, 'specs.raw.hookType')
+      ) {
+        // process here only regular ansible tasks
+        const deployedKey = res
+          ? node.type === 'namespace' ? deployedNSStr : deployedStr
+          : node.type === 'namespace' ? notDeployedNSStr : notDeployedStr
+        const statusStr =
+          deployedKey === deployedStr || deployedKey === deployedNSStr
+            ? checkmarkStatus
+            : pendingStatus
 
-    if (
-      _.get(node, 'type', '') !== 'ansiblejob' ||
-      !_.get(node, 'specs.raw.hookType')
-    ) {
-      // process here only regular ansible tasks
-      const deployedKey = res
-        ? node.type === 'namespace' ? deployedNSStr : deployedStr
-        : node.type === 'namespace' ? notDeployedNSStr : notDeployedStr
-      const statusStr =
-        deployedKey === deployedStr || deployedKey === deployedNSStr
-          ? checkmarkStatus
-          : pendingStatus
-
-      let addItemToDetails = false
-      if (resourceStatuses.size > 0) {
-        if (
-          (statusStr === checkmarkStatus &&
-            activeFilterCodes.has(checkmarkCode)) ||
-          (statusStr === pendingStatus &&
-            (activeFilterCodes.has(pendingCode) ||
-              activeFilterCodes.has(warningCode)))
-        ) {
+        let addItemToDetails = false
+        if (resourceStatuses.size > 0) {
+          if (
+            (statusStr === checkmarkStatus &&
+              activeFilterCodes.has(checkmarkCode)) ||
+            (statusStr === pendingStatus &&
+              (activeFilterCodes.has(pendingCode) ||
+                activeFilterCodes.has(warningCode)))
+          ) {
+            addItemToDetails = true
+          }
+        } else {
           addItemToDetails = true
         }
-      } else {
-        addItemToDetails = true
+
+        if (addItemToDetails) {
+          details.push({
+            labelValue: targetNS,
+            value: deployedKey,
+            status: statusStr
+          })
+        } else {
+          res = null
+        }
       }
 
-      if (addItemToDetails) {
+      if (res) {
+        //for open shift routes show location info
+        addOCPRouteLocation(node, clusterName, targetNS, details)
+
+        //for service
+        addNodeServiceLocation(node, clusterName, targetNS, details)
+
+        // add apiversion if not exist
+        if (!res.apiversion) {
+          _.assign(res, { apiversion: _.get(node, apiVersionPath) })
+        }
+
         details.push({
-          labelValue: clusterName,
-          value: deployedKey,
-          status: statusStr
+          type: 'link',
+          value: {
+            label: msgs.get(specsPropsYaml),
+            data: {
+              action: showResourceYaml,
+              cluster: res.cluster,
+              editLink: createEditLink(res)
+            }
+          },
+          indent: true
         })
-      } else {
-        res = null
       }
-    }
-
-    if (res) {
-      //for open shift routes show location info
-      addOCPRouteLocation(node, clusterName, details)
-
-      //for service
-      addNodeServiceLocation(node, clusterName, details)
-
-      // add apiversion if not exist
-      if (!res.apiversion) {
-        _.assign(res, { apiversion: _.get(node, apiVersionPath) })
-      }
-
-      details.push({
-        type: 'link',
-        value: {
-          label: msgs.get(specsPropsYaml),
-          data: {
-            action: showResourceYaml,
-            cluster: res.cluster,
-            editLink: createEditLink(res)
-          }
-        },
-        indent: true
-      })
-    }
+    })
   })
 
   details.push({
@@ -1281,9 +1339,12 @@ export const setPodDeployStatus = (
     labelKey: 'resource.deploy.pods.statuses'
   })
 
-  const podModel = _.get(node, 'specs.podModel', {})
+  const podModel = _.get(node, 'specs.podModel', [])
+  const podObjects = _.flatten(Object.values(podModel))
   const podStatusModel = _.get(updatedNode, 'podStatusMap', {})
   const podDataPerCluster = {} //pod details list for each cluster name
+  // list of target namespaces per cluster
+  const targetNamespaces = _.get(node, 'clusters.specs.targetNamespaces', {})
 
   const clusterNames = R.split(',', getClusterName(node.id, node, true))
   const clusterObjs = _.get(node, clusterObjsPath, [])
@@ -1300,62 +1361,73 @@ export const setPodDeployStatus = (
       // offline cluster, skip
       return
     }
-    const res = podStatusModel[clusterName]
-    let pulse = 'orange'
-    if (res) {
-      pulse = getPulseForData('', res.ready, res.desired, res.unavailable)
-    }
-    const valueStr = res ? `${res.ready}/${res.desired}` : notDeployedStr
+    details.push({
+      labelValue: msgs.get('topology.filter.category.clustername'),
+      value: clusterName
+    })
+    //get cluster target namespaces
+    const targetNSList = targetNamespaces[clusterName] ||
+      (podObjects.length > 0 && _.uniq(_.map(podObjects, 'namespace', ''))) || [
+      _.get(node, 'namespace', '')
+    ]
+    targetNSList.forEach(targetNS => {
+      const res = podStatusModel[`${clusterName}-${targetNS}`]
+      let pulse = 'orange'
+      if (res) {
+        pulse = getPulseForData('', res.ready, res.desired, res.unavailable)
+      }
+      const valueStr = res ? `${res.ready}/${res.desired}` : notDeployedStr
 
-    let statusStr
-    switch (pulse) {
-    case 'red':
-      statusStr = failureStatus
-      break
-    case 'yellow':
-      statusStr = warningStatus
-      break
-    case 'orange':
-      statusStr = pendingStatus
-      break
-    default:
-      statusStr = checkmarkStatus
-      break
-    }
+      let statusStr
+      switch (pulse) {
+      case 'red':
+        statusStr = failureStatus
+        break
+      case 'yellow':
+        statusStr = warningStatus
+        break
+      case 'orange':
+        statusStr = pendingStatus
+        break
+      default:
+        statusStr = checkmarkStatus
+        break
+      }
 
-    let addItemToDetails = false
-    if (resourceStatuses.size > 0) {
-      const pendingOrWanrning =
-        statusStr === pendingStatus || statusStr === warningStatus
-      if (
-        (statusStr === checkmarkStatus &&
-          activeFilterCodes.has(checkmarkCode)) ||
-        (statusStr === warningStatus && activeFilterCodes.has(warningCode)) ||
-        (pendingOrWanrning && activeFilterCodes.has(pendingCode)) ||
-        (statusStr === failureStatus && activeFilterCodes.has(failureCode))
-      ) {
+      let addItemToDetails = false
+      if (resourceStatuses.size > 0) {
+        const pendingOrWanrning =
+          statusStr === pendingStatus || statusStr === warningStatus
+        if (
+          (statusStr === checkmarkStatus &&
+            activeFilterCodes.has(checkmarkCode)) ||
+          (statusStr === warningStatus && activeFilterCodes.has(warningCode)) ||
+          (pendingOrWanrning && activeFilterCodes.has(pendingCode)) ||
+          (statusStr === failureStatus && activeFilterCodes.has(failureCode))
+        ) {
+          addItemToDetails = true
+        }
+      } else {
         addItemToDetails = true
       }
-    } else {
-      addItemToDetails = true
-    }
 
-    if (addItemToDetails) {
-      details.push({
-        labelValue: clusterName,
-        value: valueStr,
-        status: statusStr
-      })
-    }
+      if (addItemToDetails) {
+        details.push({
+          labelValue: targetNS,
+          value: valueStr,
+          status: statusStr
+        })
+      }
 
-    podDataPerCluster[clusterName] = []
+      podDataPerCluster[clusterName] = []
+    })
   })
 
   details.push({
     type: 'spacer'
   })
 
-  Object.values(podModel).forEach(pod => {
+  podObjects.forEach(pod => {
     const { status, restarts, hostIP, podIP, startedAt, cluster } = pod
 
     const podError = getPodState(pod, undefined, podErrorStates)
@@ -1385,6 +1457,10 @@ export const setPodDeployStatus = (
           {
             labelKey: 'resource.pod',
             value: pod.name
+          },
+          {
+            labelKey: 'resource.namespace',
+            value: pod.namespace
           },
           {
             labelKey: 'resource.status',
@@ -1775,10 +1851,11 @@ export const addNodeOCPRouteLocationForCluster = (
   if (!hostName && typeObject) {
     //build up the name using <route_name>-<ns>.router.default.svc.cluster.local
     Object.values(clustersList).forEach(clusterObject => {
-      if (
-        R.pathOr('NA', ['metadata', 'name'])(clusterObject) ===
-        _.get(typeObject, 'cluster', '')
-      ) {
+      const clusterName =
+        _.get(clusterObject, 'metadata.name') ||
+        _.get(clusterObject, 'name') ||
+        ''
+      if (clusterName === _.get(typeObject, 'cluster', '')) {
         const clusterHost = getClusterHost(clusterObject.consoleURL)
         hostName = `${node.name}-${node.namespace}.${clusterHost}`
       }
@@ -1812,11 +1889,12 @@ export const addNodeOCPRouteLocationForCluster = (
 }
 
 //route
-export const addOCPRouteLocation = (node, clusterName, details) => {
+export const addOCPRouteLocation = (node, clusterName, targetNS, details) => {
   if (R.pathOr('', ['specs', 'raw', 'kind'])(node) === 'Route') {
     return addNodeInfoPerCluster(
       node,
       clusterName,
+      targetNS,
       details,
       addNodeOCPRouteLocationForCluster
     )
@@ -1879,11 +1957,17 @@ export const addIngressNodeInfo = (node, details) => {
 }
 
 //for service
-export const addNodeServiceLocation = (node, clusterName, details) => {
+export const addNodeServiceLocation = (
+  node,
+  clusterName,
+  targetNS,
+  details
+) => {
   if (R.pathOr('', ['specs', 'raw', 'kind'])(node) === 'Service') {
     return addNodeInfoPerCluster(
       node,
       clusterName,
+      targetNS,
       details,
       addNodeServiceLocationForCluster
     ) //process only services
@@ -1895,6 +1979,7 @@ export const addNodeServiceLocation = (node, clusterName, details) => {
 export const addNodeInfoPerCluster = (
   node,
   clusterName,
+  targetNS,
   details,
   getDetailsFunction
 ) => {
@@ -1902,8 +1987,12 @@ export const addNodeInfoPerCluster = (
   const resourceMap = _.get(node, `specs.${node.type}Model`, {})
 
   const locationDetails = []
-  const typeObject = resourceMap[`${resourceName}-${clusterName}`]
-
+  const resourcesForCluster =
+    resourceMap[`${resourceName}-${clusterName}`] || []
+  const typeObject = _.find(
+    resourcesForCluster,
+    obj => _.get(obj, 'namespace', '') === targetNS
+  )
   if (typeObject) {
     getDetailsFunction(node, typeObject, locationDetails)
   }

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -1616,69 +1616,71 @@ export const setSubscriptionDeployStatus = (node, details, activeFilters) => {
   if (resourceStatuses.size > 0) {
     resourceMap = filteredResourceMap
   }
-  Object.values(resourceMap).forEach(subscription => {
-    const isLocalFailedSubscription =
-      subscription._hubClusterResource &&
-      R.contains('Fail', R.pathOr('Fail', ['status'])(subscription))
-    if (isLocalFailedSubscription) {
-      localSubscriptionFailed = true
-    }
-    const isLinkedLocalPlacementSubs =
-      isLocalPlacementSubs ||
-      (_.get(subscription, 'localPlacement', '') === 'true' &&
-        _.get(subscription, 'cluster', '') === LOCAL_HUB_NAME)
-    if (
-      isLinkedLocalPlacementSubs ||
-      !subscription._hubClusterResource ||
-      isLocalFailedSubscription
-    ) {
-      const subscriptionPulse = R.contains(
-        'Fail',
-        R.pathOr('', ['status'])(subscription)
-      )
-        ? failureStatus
-        : R.pathOr(null, ['status'])(subscription) === null
-          ? warningStatus
-          : checkmarkStatus
+  Object.values(resourceMap).forEach(subscriptions => {
+    subscriptions.forEach(subscription => {
+      const isLocalFailedSubscription =
+        subscription._hubClusterResource &&
+        R.contains('Fail', R.pathOr('Fail', ['status'])(subscription))
+      if (isLocalFailedSubscription) {
+        localSubscriptionFailed = true
+      }
+      const isLinkedLocalPlacementSubs =
+        isLocalPlacementSubs ||
+        (_.get(subscription, 'localPlacement', '') === 'true' &&
+          _.get(subscription, 'cluster', '') === LOCAL_HUB_NAME)
+      if (
+        isLinkedLocalPlacementSubs ||
+        !subscription._hubClusterResource ||
+        isLocalFailedSubscription
+      ) {
+        const subscriptionPulse = R.contains(
+          'Fail',
+          R.pathOr('', ['status'])(subscription)
+        )
+          ? failureStatus
+          : R.pathOr(null, ['status'])(subscription) === null
+            ? warningStatus
+            : checkmarkStatus
 
-      //if subscription has not status show an error message
-      const emptyStatusErrorMsg = subscription._hubClusterResource
-        ? msgs.get('resource.subscription.nostatus.hub', ['Propagated'])
-        : msgs.get('resource.subscription.nostatus.remote', ['Subscribed'])
+        //if subscription has not status show an error message
+        const emptyStatusErrorMsg = subscription._hubClusterResource
+          ? msgs.get('resource.subscription.nostatus.hub', ['Propagated'])
+          : msgs.get('resource.subscription.nostatus.remote', ['Subscribed'])
 
-      const subscriptionStatus = R.pathOr(emptyStatusErrorMsg, ['status'])(
-        subscription
-      )
-      details.push({
-        labelValue: subscription.cluster,
-        value: subscriptionStatus,
-        status: subscriptionPulse
-      })
-      !isLocalPlacementSubs &&
-        isLinkedLocalPlacementSubs &&
+        const subscriptionStatus = R.pathOr(emptyStatusErrorMsg, ['status'])(
+          subscription
+        )
         details.push({
-          labelKey: 'resource.subscription.local',
-          value: 'true'
+          labelValue: subscription.cluster,
+          value: subscriptionStatus,
+          status: subscriptionPulse
         })
+        !isLocalPlacementSubs &&
+          isLinkedLocalPlacementSubs &&
+          details.push({
+            labelKey: 'resource.subscription.local',
+            value: 'true'
+          })
 
-      setClusterWindowStatus(windowStatusArray, subscription, details)
+        setClusterWindowStatus(windowStatusArray, subscription, details)
+
+        details.push({
+          type: 'link',
+          value: {
+            label: msgs.get(specsPropsYaml),
+            data: {
+              action: showResourceYaml,
+              cluster: subscription.cluster,
+              editLink: createEditLink(subscription)
+            }
+          },
+          indent: true
+        })
+      }
 
       details.push({
-        type: 'link',
-        value: {
-          label: msgs.get(specsPropsYaml),
-          data: {
-            action: showResourceYaml,
-            cluster: subscription.cluster,
-            editLink: createEditLink(subscription)
-          }
-        },
-        indent: true
+        type: 'spacer'
       })
-    }
-
-    details.push({
-      type: 'spacer'
     })
   })
 

--- a/src-web/components/Topology/viewer/defaults/details.js
+++ b/src-web/components/Topology/viewer/defaults/details.js
@@ -120,7 +120,7 @@ function addK8Details(node, updatedNode, details, activeFilters) {
   if (node && R.pathOr('', ['specs', 'pulse'])(node) !== 'orange') {
     const kindModel = _.get(node, `specs.${type}Model`, {})
     let computedNSList = []
-    Object.values(kindModel).forEach(item => {
+    _.flatten(Object.values(kindModel)).forEach(item => {
       computedNSList = R.union(computedNSList, [item.namespace])
     })
 

--- a/tests/jest/components/Topology/viewer/defaults/details.test.js
+++ b/tests/jest/components/Topology/viewer/defaults/details.test.js
@@ -545,43 +545,53 @@ describe("getNodeDetails deployment node", () => {
     },
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 3,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            cluster: "feng",
+            namespace: "default",
+            ready: 3,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       podModel: {
-        "mortgagedc-deploy-1-q9b5r-feng": {
-          cluster: "feng",
-          container: "mortgagedc-mortgage",
-          hostIP: "1.1.1.1",
-          image: "fxiang/mortgage:0.4.0",
-          kind: "pod",
-          label:
-            "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
-          name: "mortgagedc-deploy-1-q9b5r",
-          namespace: "default",
-          podIP: "10.128.2.80",
-          restarts: 0,
-          selfLink: "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
-          status: "Running"
-        },
-        "mortgagedc-deploy-1-q9b5rr-feng": {
-          cluster: "feng",
-          container: "mortgagedc-mortgage",
-          hostIP: "1.1.1.1",
-          image: "fxiang/mortgage:0.4.0",
-          kind: "pod",
-          label:
-            "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
-          name: "mortgagedc-deploy-1-q9b5rr",
-          namespace: "default",
-          podIP: "10.128.2.80",
-          restarts: 0,
-          selfLink: "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
-          status: "Running"
-        }
+        "mortgagedc-deploy-1-q9b5r-feng": [
+          {
+            cluster: "feng",
+            container: "mortgagedc-mortgage",
+            hostIP: "1.1.1.1",
+            image: "fxiang/mortgage:0.4.0",
+            kind: "pod",
+            label:
+              "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
+            name: "mortgagedc-deploy-1-q9b5r",
+            namespace: "default",
+            podIP: "10.128.2.80",
+            restarts: 0,
+            selfLink:
+              "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
+            status: "Running"
+          }
+        ],
+        "mortgagedc-deploy-1-q9b5rr-feng": [
+          {
+            cluster: "feng",
+            container: "mortgagedc-mortgage",
+            hostIP: "1.1.1.1",
+            image: "fxiang/mortgage:0.4.0",
+            kind: "pod",
+            label:
+              "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
+            name: "mortgagedc-deploy-1-q9b5rr",
+            namespace: "default",
+            podIP: "10.128.2.80",
+            restarts: 0,
+            selfLink:
+              "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
+            status: "Running"
+          }
+        ]
       },
       raw: {
         apiVersion: "apps/v1",
@@ -592,6 +602,11 @@ describe("getNodeDetails deployment node", () => {
           namespace: "default"
         },
         spec: {
+          metadata: {
+            labels: { app: "mortgage-app-mortgage" },
+            name: "mortgage-app-deploy",
+            namespace: "default"
+          },
           replicas: 1,
           selector: {
             matchLabels: { app: "mortgage-app-mortgage" }
@@ -688,13 +703,15 @@ describe("getNodeDetails deployment node", () => {
           },
           specs: {
             podModel: {
-              "mortgage-app-deploy-55c65b9c8f-6v9bn": {
-                cluster: "cluster1",
-                hostIP: "1.1.1.1",
-                status: "Running",
-                restarts: 0,
-                podIP: "1.1.1.1"
-              }
+              "mortgage-app-deploy-55c65b9c8f-6v9bn": [
+                {
+                  cluster: "cluster1",
+                  hostIP: "1.1.1.1",
+                  status: "Running",
+                  restarts: 0,
+                  podIP: "1.1.1.1"
+                }
+              ]
             }
           }
         }
@@ -703,174 +720,187 @@ describe("getNodeDetails deployment node", () => {
   };
 
   const expectedResult = [
-    { type: "spacer" },
-    { labelKey: "prop.details.section", type: "label" },
-    { type: "spacer" },
     {
-      indent: undefined,
-      labelKey: "resource.type",
-      labelValue: undefined,
-      status: undefined,
+      type: "spacer"
+    },
+    {
       type: "label",
+      labelKey: "prop.details.section"
+    },
+    {
+      type: "spacer"
+    },
+    {
+      type: "label",
+      labelKey: "resource.type",
       value: "deployment"
     },
     {
-      indent: undefined,
-      labelKey: "resource.api.version",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.api.version",
       value: "apps/v1"
     },
     {
-      indent: undefined,
-      labelKey: "resource.namespace",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.namespace",
       value: "default"
     },
     {
-      indent: undefined,
-      labelKey: "raw.spec.metadata.label",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "raw.spec.metadata.label",
       value: "app=mortgage-app-mortgage"
     },
     {
-      indent: undefined,
-      labelKey: "raw.spec.replicas",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "raw.spec.replicas",
       value: "1"
     },
     {
-      indent: undefined,
-      labelKey: "raw.spec.selector",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "raw.spec.selector",
       value: "app=mortgage-app-mortgage"
     },
-    { type: "spacer" },
-    { type: "spacer" },
-    { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "feng", status: "pending", value: "Not Deployed" },
-    { labelValue: "cluster1", status: "pending", value: "Not Deployed" },
-    { labelValue: "cluster2", status: "pending", value: "Not Deployed" },
-    { type: "spacer" },
-    { type: "spacer" },
-    { labelValue: "Pod details for {0}", type: "label" },
     {
-      indent: undefined,
-      labelKey: "resource.pod",
-      labelValue: undefined,
-      status: undefined,
+      type: "spacer"
+    },
+    {
+      type: "spacer"
+    },
+    {
       type: "label",
+      labelKey: "resource.deploy.pods.statuses"
+    },
+    {
+      labelValue: "Cluster name",
+      value: "feng"
+    },
+    {
+      labelValue: "default",
+      value: "Not Deployed",
+      status: "pending"
+    },
+    {
+      labelValue: "Cluster name",
+      value: "cluster1"
+    },
+    {
+      labelValue: "default",
+      value: "Not Deployed",
+      status: "pending"
+    },
+    {
+      labelValue: "Cluster name",
+      value: "cluster2"
+    },
+    {
+      labelValue: "default",
+      value: "Not Deployed",
+      status: "pending"
+    },
+    {
+      type: "spacer"
+    },
+    {
+      type: "spacer"
+    },
+    {
+      type: "label",
+      labelValue: "Pod details for {0}"
+    },
+    {
+      type: "label",
+      labelKey: "resource.pod",
       value: "mortgagedc-deploy-1-q9b5r"
     },
     {
-      indent: undefined,
-      labelKey: "resource.status",
-      labelValue: undefined,
-      status: "checkmark",
       type: "label",
-      value: "Running"
+      labelKey: "resource.namespace",
+      value: "default"
     },
     {
-      indent: true,
+      type: "label",
+      labelKey: "resource.status",
+      value: "Running",
+      status: "checkmark"
+    },
+    {
       type: "link",
       value: {
+        label: "View Pod YAML and Logs",
         data: {
           action: "show_resource_yaml",
           cluster: "feng",
           editLink:
             "/resources?cluster=feng&kind=pod&name=mortgagedc-deploy-1-q9b5r&namespace=default"
-        },
-        label: "View Pod YAML and Logs"
-      }
+        }
+      },
+      indent: true
     },
     {
-      indent: undefined,
-      labelKey: "resource.restarts",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.restarts",
       value: "0"
     },
     {
-      indent: undefined,
-      labelKey: "resource.hostip",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.hostip",
       value: "1.1.1.1, 10.128.2.80"
     },
     {
-      indent: undefined,
-      labelKey: "resource.created",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.created",
       value: "-"
     },
-    { type: "spacer" },
     {
-      indent: undefined,
-      labelKey: "resource.pod",
-      labelValue: undefined,
-      status: undefined,
+      type: "spacer"
+    },
+    {
       type: "label",
+      labelKey: "resource.pod",
       value: "mortgagedc-deploy-1-q9b5rr"
     },
     {
-      indent: undefined,
-      labelKey: "resource.status",
-      labelValue: undefined,
-      status: "checkmark",
       type: "label",
-      value: "Running"
+      labelKey: "resource.namespace",
+      value: "default"
     },
     {
-      indent: true,
+      type: "label",
+      labelKey: "resource.status",
+      value: "Running",
+      status: "checkmark"
+    },
+    {
       type: "link",
       value: {
+        label: "View Pod YAML and Logs",
         data: {
           action: "show_resource_yaml",
           cluster: "feng",
           editLink:
             "/resources?cluster=feng&kind=pod&name=mortgagedc-deploy-1-q9b5rr&namespace=default"
-        },
-        label: "View Pod YAML and Logs"
-      }
+        }
+      },
+      indent: true
     },
     {
-      indent: undefined,
-      labelKey: "resource.restarts",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.restarts",
       value: "0"
     },
     {
-      indent: undefined,
-      labelKey: "resource.hostip",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.hostip",
       value: "1.1.1.1, 10.128.2.80"
     },
     {
-      indent: undefined,
-      labelKey: "resource.created",
-      labelValue: undefined,
-      status: undefined,
       type: "label",
+      labelKey: "resource.created",
       value: "-"
     },
-    { type: "spacer" }
+    {
+      type: "spacer"
+    }
   ];
 
   it("should process the node, deployment node", () => {
@@ -964,7 +994,8 @@ describe("getNodeDetails helm node", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "local-cluster", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "local-cluster" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
 

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -497,62 +497,71 @@ describe("syncControllerRevisionPodStatusMap", () => {
 });
 
 describe("fixMissingStateOptions", () => {
-  const itemNoAvailableReady = {
-    _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
-    apiversion: "v1",
-    created: "2021-01-28T19:24:10Z",
-    current: 1,
-    apigroup: "apps",
-    kind: "statefulset",
-    name: "mariadb",
-    namespace: "val-mariadb-helm",
-    selfLink: "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
-    cluster: "fxiang-eks",
-    desired: 1,
-    label:
-      "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
-    _clusterNamespace: "fxiang-eks",
-    _rbac: "fxiang-eks_apps_statefulsets"
-  };
+  const itemNoAvailableReady = [
+    {
+      _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
+      apiversion: "v1",
+      created: "2021-01-28T19:24:10Z",
+      current: 1,
+      apigroup: "apps",
+      kind: "statefulset",
+      name: "mariadb",
+      namespace: "val-mariadb-helm",
+      selfLink:
+        "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
+      cluster: "fxiang-eks",
+      desired: 1,
+      label:
+        "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
+      _clusterNamespace: "fxiang-eks",
+      _rbac: "fxiang-eks_apps_statefulsets"
+    }
+  ];
 
-  const itemNoAvailable = {
-    _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
-    apiversion: "v1",
-    created: "2021-01-28T19:24:10Z",
-    current: 1,
-    apigroup: "apps",
-    kind: "statefulset",
-    name: "mariadb",
-    namespace: "val-mariadb-helm",
-    selfLink: "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
-    cluster: "fxiang-eks",
-    desired: 1,
-    ready: 1,
-    label:
-      "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
-    _clusterNamespace: "fxiang-eks",
-    _rbac: "fxiang-eks_apps_statefulsets"
-  };
+  const itemNoAvailable = [
+    {
+      _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
+      apiversion: "v1",
+      created: "2021-01-28T19:24:10Z",
+      current: 1,
+      apigroup: "apps",
+      kind: "statefulset",
+      name: "mariadb",
+      namespace: "val-mariadb-helm",
+      selfLink:
+        "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
+      cluster: "fxiang-eks",
+      desired: 1,
+      ready: 1,
+      label:
+        "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
+      _clusterNamespace: "fxiang-eks",
+      _rbac: "fxiang-eks_apps_statefulsets"
+    }
+  ];
 
-  const itemComplete = {
-    _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
-    apiversion: "v1",
-    created: "2021-01-28T19:24:10Z",
-    current: 1,
-    apigroup: "apps",
-    kind: "statefulset",
-    name: "mariadb",
-    namespace: "val-mariadb-helm",
-    selfLink: "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
-    cluster: "fxiang-eks",
-    desired: 1,
-    ready: 1,
-    label:
-      "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
-    _clusterNamespace: "fxiang-eks",
-    _rbac: "fxiang-eks_apps_statefulsets",
-    available: 1
-  };
+  const itemComplete = [
+    {
+      _uid: "fxiang-eks/7c30f5d2-a522-40be-a8a6-5e833012b17b",
+      apiversion: "v1",
+      created: "2021-01-28T19:24:10Z",
+      current: 1,
+      apigroup: "apps",
+      kind: "statefulset",
+      name: "mariadb",
+      namespace: "val-mariadb-helm",
+      selfLink:
+        "/apis/apps/v1/namespaces/val-mariadb-helm/statefulsets/mariadb",
+      cluster: "fxiang-eks",
+      desired: 1,
+      ready: 1,
+      label:
+        "app.kubernetes.io/component=primary; app.kubernetes.io/instance=mariadb; app.kubernetes.io/managed-by=Helm; app.kubernetes.io/name=mariadb; helm.sh/chart=mariadb-9.3.0",
+      _clusterNamespace: "fxiang-eks",
+      _rbac: "fxiang-eks_apps_statefulsets",
+      available: 1
+    }
+  ];
 
   it("should get complete item when no available and ready set", () => {
     expect(fixMissingStateOptions(itemNoAvailableReady)).toEqual(itemComplete);
@@ -564,10 +573,6 @@ describe("fixMissingStateOptions", () => {
 
   it("should get complete item when full data set", () => {
     expect(fixMissingStateOptions(itemComplete)).toEqual(itemComplete);
-  });
-
-  it("should return undefined", () => {
-    expect(fixMissingStateOptions(undefined)).toEqual(undefined);
   });
 });
 

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -315,19 +315,32 @@ describe("getActiveFilterCodes all statuses filtered", () => {
 
 describe("filterSubscriptionObject simple subscription object", () => {
   const subs = {
-    sub1: {
-      status: "Subscribed"
-    },
-    sub2: {
-      status: "Propagated"
-    },
-    sub3: {
-      status: "Fail"
-    }
+    sub1: [
+      {
+        status: "Subscribed"
+      }
+    ],
+    sub2: [
+      {
+        status: "Propagated"
+      }
+    ],
+    sub3: [
+      {
+        status: "Fail"
+      }
+    ]
+  };
+  const resultSubs = {
+    sub1: { status: "Subscribed" },
+    sub2: { status: "Propagated" },
+    sub3: { status: "Fail" }
   };
 
   it("should filter object", () => {
-    expect(filterSubscriptionObject(subs, new Set([3, 2, 0]))).toEqual(subs);
+    expect(filterSubscriptionObject(subs, new Set([3, 2, 0]))).toEqual(
+      resultSubs
+    );
   });
 });
 
@@ -346,8 +359,8 @@ describe("getPulseStatusForSubscription no subscriptionItem.status", () => {
     specs: {
       raw: { spec: {} },
       subscriptionModel: {
-        "mortgagedc-subscription-braveman": {},
-        "mortgagedc-subscription-braveman2": {}
+        "mortgagedc-subscription-braveman": [],
+        "mortgagedc-subscription-braveman2": []
       },
       row: 12
     },

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -63,9 +63,12 @@ const ansibleSuccess = {
       }
     },
     ansiblejobModel: {
-      "bigjoblaunch-local-cluster": {
-        label: "tower_job_id=999999999"
-      }
+      "bigjoblaunch-local-cluster": [
+        {
+          label: "tower_job_id=999999999",
+          namespace: "default"
+        }
+      ]
     }
   }
 };
@@ -119,9 +122,13 @@ const ansibleError2 = {
       }
     },
     ansiblejobModel: {
-      "bigjoblaunch-local-cluster": {
-        label: "tower_job_id=999999999"
-      }
+      "bigjoblaunch-local-cluster": [
+        {
+          label: "tower_job_id=999999999",
+          cluster: "local-cluster",
+          namespace: "default"
+        }
+      ]
     }
   }
 };
@@ -245,17 +252,19 @@ const modelResult = {
   "mortgagedc-subscription": {
     specs: {
       subscriptionModel: {
-        "mortgagedc-subscription-braveman": {
-          cluster: "braveman",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          selfLink:
-            "/apis/apps.open-cluster-management.io/v1/namespaces/default/subscriptions/mortgagedc-subscription",
-          status: "Subscribed"
-        }
+        "mortgagedc-subscription-braveman": [
+          {
+            cluster: "braveman",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            selfLink:
+              "/apis/apps.open-cluster-management.io/v1/namespaces/default/subscriptions/mortgagedc-subscription",
+            status: "Subscribed"
+          }
+        ]
       }
     },
     type: "subscription"
@@ -264,12 +273,14 @@ const modelResult = {
   "route-unsecured-braveman": {
     specs: {
       routeModel: {
-        "unsecured-braveman": {
-          cluster: "braveman",
-          kind: "route",
-          name: "unsecured",
-          namespace: "default"
-        }
+        "unsecured-braveman": [
+          {
+            cluster: "braveman",
+            kind: "route",
+            name: "unsecured",
+            namespace: "default"
+          }
+        ]
       }
     }
   }
@@ -311,29 +322,36 @@ describe("getPulseForNodeWithPodStatus ", () => {
     type: "deployment",
     specs: {
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-6v9bn": {
-          cluster: "feng",
-          hostIP: "1.1.1.1",
-          status: "Error",
-          startedAt: "2020-04-20T22:03:52Z",
-          restarts: 0,
-          podIP: "1.1.1.1"
-        }
+        "mortgage-app-deploy-55c65b9c8f-6v9bn": [
+          {
+            cluster: "feng",
+            namespace: "default",
+            hostIP: "1.1.1.1",
+            status: "Error",
+            startedAt: "2020-04-20T22:03:52Z",
+            restarts: 0,
+            podIP: "1.1.1.1"
+          }
+        ]
       },
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          desired: 3,
-          unavailable: 1
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3,
+            unavailable: 1
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           replicas: 1,
@@ -417,29 +435,36 @@ describe("getPulseForNodeWithPodStatus controllerrevision type", () => {
     type: "controllerrevision",
     specs: {
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-6v9bn": {
-          cluster: "feng",
-          hostIP: "1.1.1.1",
-          status: "Error",
-          startedAt: "2020-04-20T22:03:52Z",
-          restarts: 0,
-          podIP: "1.1.1.1"
-        }
+        "mortgage-app-deploy-55c65b9c8f-6v9bn": [
+          {
+            cluster: "feng",
+            namespace: "default",
+            hostIP: "1.1.1.1",
+            status: "Error",
+            startedAt: "2020-04-20T22:03:52Z",
+            restarts: 0,
+            podIP: "1.1.1.1"
+          }
+        ]
       },
       controllerrevisionModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          desired: 3,
-          unavailable: 1
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3,
+            unavailable: 1
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "ControllerRevision",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           replicas: 1,
@@ -523,28 +548,35 @@ describe("getPulseForNodeWithPodStatus controllerrevision type no desired", () =
     type: "controllerrevision",
     specs: {
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-6v9bn": {
-          cluster: "feng",
-          hostIP: "1.1.1.1",
-          status: "Error",
-          startedAt: "2020-04-20T22:03:52Z",
-          restarts: 0,
-          podIP: "1.1.1.1"
-        }
+        "mortgage-app-deploy-55c65b9c8f-6v9bn": [
+          {
+            namespace: "default",
+            cluster: "feng",
+            hostIP: "1.1.1.1",
+            status: "Error",
+            startedAt: "2020-04-20T22:03:52Z",
+            restarts: 0,
+            podIP: "1.1.1.1"
+          }
+        ]
       },
       controllerrevisionModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          unavailable: 1
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            ready: 2,
+            unavailable: 1,
+            namespace: "default"
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "ControllerRevision",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           replicas: 1,
@@ -628,18 +660,22 @@ describe("getPulseForNodeWithPodStatus no replica", () => {
     type: "deployment",
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            ready: 2,
+            desired: 3,
+            namespace: "default"
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           selector: {
@@ -1762,14 +1798,6 @@ describe("setSubscriptionDeployStatus for node type different then subscription 
 });
 
 describe("setupResourceModel ", () => {
-  it("setupResourceModel", () => {
-    expect(
-      setupResourceModel(resourceList, resourceMap, false, false, topology)
-    ).toEqual(modelResult);
-  });
-});
-
-describe("setupResourceModel ", () => {
   it("return setupResourceModel for grouped objects", () => {
     expect(
       setupResourceModel(resourceList, resourceMap, true, false, topology)
@@ -1780,7 +1808,7 @@ describe("setupResourceModel ", () => {
 describe("setupResourceModel undefined 1", () => {
   it("return setupResourceModel for undefined 1 ", () => {
     expect(setupResourceModel(undefined, resourceMap, true, topology)).toEqual(
-      modelResult
+      resourceMap
     );
   });
 });
@@ -2063,11 +2091,14 @@ describe("computeNodeStatus ", () => {
     specs: {
       pulse: "red",
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       }
     }
   };
@@ -2107,12 +2138,20 @@ describe("computeNodeStatus ", () => {
     type: "deployment",
     specs: {
       pulse: "green",
+      raw: {
+        metadata: {
+          namespace: "default"
+        }
+      },
       deploymentModel: {
-        "mortgage-app-deployable-feng": {
-          ready: 2,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deployable-feng": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       }
     }
   };
@@ -2153,15 +2192,21 @@ describe("computeNodeStatus ", () => {
     specs: {
       raw: {
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           replicas: 3
         }
       },
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 3,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 3,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       }
     }
   };
@@ -2201,17 +2246,21 @@ describe("computeNodeStatus ", () => {
     type: "deployment",
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 2,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         spec: {
@@ -2308,15 +2357,18 @@ describe("computeNodeStatus ", () => {
           },
           specs: {
             podModel: {
-              "mortgage-app-deploy-55c65b9c8f-6v9bn": {
-                cluster: "cluster1",
-                hostIP: "1.1.1.1",
-                status: "Running",
-                startedAt: "2020-04-20T22:03:52Z",
-                restarts: 0,
-                podIP: "1.1.1.1",
-                startedAt: "Monday"
-              }
+              "mortgage-app-deploy-55c65b9c8f-6v9bn": [
+                {
+                  namespace: "default",
+                  cluster: "cluster1",
+                  hostIP: "1.1.1.1",
+                  status: "Running",
+                  startedAt: "2020-04-20T22:03:52Z",
+                  restarts: 0,
+                  podIP: "1.1.1.1",
+                  startedAt: "Monday"
+                }
+              ]
             }
           }
         }
@@ -2359,17 +2411,21 @@ describe("computeNodeStatus ", () => {
     type: "deployment",
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng4": {
-          ready: 2,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng4": [
+          {
+            namespace: "default",
+            ready: 2,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         spec: {
@@ -2517,54 +2573,64 @@ describe("computeNodeStatus ", () => {
     type: "deployment",
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 3,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 3,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       podModel: {
-        "mortgagedc-deploy-1-q9b5r-feng": {
-          cluster: "cluster1",
-          container: "mortgagedc-mortgage",
-          created: "2020-04-20T22:03:52Z",
-          hostIP: "1.1.1.1",
-          image: "fxiang/mortgage:0.4.0",
-          kind: "pod",
-          label:
-            "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
-          name: "mortgagedc-deploy-1-q9b5r",
-          namespace: "default",
-          podIP: "10.128.2.80",
-          restarts: 0,
-          selfLink: "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
-          startedAt: "2020-04-20T22:03:52Z",
-          status: "CrashLoopBackOff"
-        },
-        "mortgagedc-deploy-1-q9b5rr-feng": {
-          cluster: "feng2",
-          container: "mortgagedc-mortgage",
-          created: "2020-04-20T22:03:52Z",
-          hostIP: "1.1.1.1",
-          image: "fxiang/mortgage:0.4.0",
-          kind: "pod",
-          label:
-            "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
-          name: "mortgagedc-deploy-1-q9b5rr",
-          namespace: "default",
-          podIP: "10.128.2.80",
-          restarts: 0,
-          selfLink: "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
-          startedAt: "2020-04-20",
-          status: "Running"
-        }
+        "mortgagedc-deploy-1-q9b5r-feng": [
+          {
+            cluster: "feng",
+            container: "mortgagedc-mortgage",
+            created: "2020-04-20T22:03:52Z",
+            hostIP: "1.1.1.1",
+            image: "fxiang/mortgage:0.4.0",
+            kind: "pod",
+            label:
+              "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
+            name: "mortgagedc-deploy-1-q9b5r",
+            namespace: "default",
+            podIP: "10.128.2.80",
+            restarts: 0,
+            selfLink:
+              "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
+            startedAt: "2020-04-20T22:03:52Z",
+            status: "CrashLoopBackOff"
+          }
+        ],
+        "mortgagedc-deploy-1-q9b5rr-feng": [
+          {
+            cluster: "feng",
+            container: "mortgagedc-mortgage",
+            created: "2020-04-20T22:03:52Z",
+            hostIP: "1.1.1.1",
+            image: "fxiang/mortgage:0.4.0",
+            kind: "pod",
+            label:
+              "app=mortgagedc-mortgage; deployment=mortgagedc-deploy-1; deploymentConfig=mortgagedc-mortgage; deploymentconfig=mortgagedc-deploy",
+            name: "mortgagedc-deploy-1-q9b5rr",
+            namespace: "default",
+            podIP: "10.128.2.80",
+            restarts: 0,
+            selfLink:
+              "/api/v1/namespaces/default/pods/mortgagedc-deploy-1-q9b5r",
+            startedAt: "2020-04-20",
+            status: "Running"
+          }
+        ]
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           replicas: 1,
@@ -2711,18 +2777,22 @@ describe("computeNodeStatus ", () => {
     type: "deployment",
     specs: {
       deploymentModel: {
-        "mortgage-app-deploy-feng": {
-          ready: 3,
-          desired: 3
-        },
-        "mortgage-app-deploy-cluster1": {}
+        "mortgage-app-deploy-feng": [
+          {
+            namespace: "default",
+            ready: 3,
+            desired: 3
+          }
+        ],
+        "mortgage-app-deploy-cluster1": []
       },
       raw: {
         apiVersion: "apps/v1",
         kind: "Deployment",
         metadata: {
           labels: { app: "mortgage-app-mortgage" },
-          name: "mortgage-app-deploy"
+          name: "mortgage-app-deploy",
+          namespace: "default"
         },
         spec: {
           replicas: 1,
@@ -3097,15 +3167,19 @@ describe("setResourceDeployStatus 1 ", () => {
   };
   const result = [
     { type: "spacer" },
-    { labelKey: "resource.deploy.statuses", type: "label" },
+    { type: "label", labelKey: "resource.deploy.statuses" },
     { type: "spacer" },
-    { labelValue: "braveman", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "braveman" },
+    { labelValue: "", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
-    { labelValue: "sharingpenguin", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "sharingpenguin" },
+    { labelValue: "", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
-    { labelValue: "relievedox", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "relievedox" },
+    { labelValue: "", value: "Not Deployed", status: "pending" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus not deployed 1", () => {
@@ -3168,6 +3242,7 @@ describe("setResourceDeployStatus ansiblejob ", () => {
       value: "successful"
     },
     { type: "spacer" },
+    { labelValue: "Cluster name", value: "local-cluster" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus ansiblejob", () => {
@@ -3191,9 +3266,13 @@ describe("setResourceDeployStatus ansiblejob no specs.raw.spec", () => {
         }
       },
       ansiblejobModel: {
-        "bigjoblaunch-local-cluster": {
-          label: "tower_job_id=999999999"
-        }
+        "bigjoblaunch-local-cluster": [
+          {
+            label: "tower_job_id=999999999",
+            cluster: "local-cluster",
+            namespace: "default"
+          }
+        ]
       }
     }
   };
@@ -3247,9 +3326,13 @@ describe("setResourceDeployStatus ansiblejob no status", () => {
         }
       },
       ansiblejobModel: {
-        "bigjoblaunch-local-cluster": {
-          label: "tower_job_id=999999999"
-        }
+        "bigjoblaunch-local-cluster": [
+          {
+            label: "tower_job_id=999999999",
+            cluster: "local-cluster",
+            namespace: "default"
+          }
+        ]
       }
     }
   };
@@ -3331,14 +3414,15 @@ describe("setResourceDeployStatus ansiblejob no status", () => {
         "Use View Resource YAML link below to view the Ansible Job details. Look for the message section and follow the debug instructions available there."
     },
     { type: "spacer" },
+    { labelValue: "Cluster name", value: "local-cluster" },
     {
       indent: true,
       type: "link",
       value: {
         data: {
           action: "show_resource_yaml",
-          cluster: undefined,
-          editLink: "/resources?cluster=local-cluster"
+          cluster: "local-cluster",
+          editLink: "/resources?cluster=local-cluster&namespace=default"
         },
         label: "View Resource YAML"
       }
@@ -3352,7 +3436,7 @@ describe("setResourceDeployStatus ansiblejob no status", () => {
   it("setResourceDeployStatus ansiblejob no status 1", () => {
     expect(setResourceDeployStatus(ansibleError, [], {})).toEqual(result1);
   });
-  it("setResourceDeployStatus ansiblejob no status 2", () => {
+  it("etResourceDeployStatus ansiblejob with error status", () => {
     expect(setResourceDeployStatus(ansibleError2, [], {})).toEqual(result2);
   });
 });
@@ -3379,20 +3463,23 @@ describe("setResourceDeployStatus 2 ", () => {
     specs: {
       raw: {
         metadata: {
-          name: "mortgage-app-svc"
+          name: "mortgage-app-svc",
+          namespace: "default"
         }
       },
       serviceModel: {
-        "mortgage-app-svc-possiblereptile": {
-          cluster: "possiblereptile",
-          clusterIP: "172.30.140.196",
-          created: "2020-04-20T22:03:01Z",
-          kind: "service",
-          label: "app=mortgage-app-mortgage",
-          name: "mortgage-app-svc",
-          namespace: "default",
-          port: "9080:31558/TCP"
-        }
+        "mortgage-app-svc-possiblereptile": [
+          {
+            cluster: "possiblereptile",
+            clusterIP: "172.30.140.196",
+            created: "2020-04-20T22:03:01Z",
+            kind: "service",
+            label: "app=mortgage-app-mortgage",
+            name: "mortgage-app-svc",
+            namespace: "default",
+            port: "9080:31558/TCP"
+          }
+        ]
       }
     }
   };
@@ -3400,7 +3487,8 @@ describe("setResourceDeployStatus 2 ", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "checkmark", value: "Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "checkmark", value: "Deployed" },
     {
       indent: true,
       type: "link",
@@ -3416,7 +3504,7 @@ describe("setResourceDeployStatus 2 ", () => {
     },
     { type: "spacer" }
   ];
-  it("setResourceDeployStatus deployed 2", () => {
+  it("setResourceDeployStatus deployed as green", () => {
     expect(setResourceDeployStatus(node, [], {})).toEqual(result);
   });
 });
@@ -3443,20 +3531,23 @@ describe("setResourceDeployStatus 2 with filter green", () => {
     specs: {
       raw: {
         metadata: {
-          name: "mortgage-app-svc"
+          name: "mortgage-app-svc",
+          namespace: "default"
         }
       },
       serviceModel: {
-        "mortgage-app-svc-possiblereptile": {
-          cluster: "possiblereptile",
-          clusterIP: "172.30.140.196",
-          created: "2020-04-20T22:03:01Z",
-          kind: "service",
-          label: "app=mortgage-app-mortgage",
-          name: "mortgage-app-svc",
-          namespace: "default",
-          port: "9080:31558/TCP"
-        }
+        "mortgage-app-svc-possiblereptile": [
+          {
+            cluster: "possiblereptile",
+            clusterIP: "172.30.140.196",
+            created: "2020-04-20T22:03:01Z",
+            kind: "service",
+            label: "app=mortgage-app-mortgage",
+            name: "mortgage-app-svc",
+            namespace: "default",
+            port: "9080:31558/TCP"
+          }
+        ]
       }
     }
   };
@@ -3467,7 +3558,8 @@ describe("setResourceDeployStatus 2 with filter green", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "checkmark", value: "Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "checkmark", value: "Deployed" },
     {
       indent: true,
       type: "link",
@@ -3510,6 +3602,7 @@ describe("setResourceDeployStatus 2 with filter yellow", () => {
     specs: {
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-svc"
         }
       },
@@ -3523,7 +3616,8 @@ describe("setResourceDeployStatus 2 with filter yellow", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus deployed 2 - should filter resource", () => {
@@ -3553,6 +3647,7 @@ describe("setResourceDeployStatus 2 with filter orange", () => {
     specs: {
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-svc"
         }
       },
@@ -3566,7 +3661,8 @@ describe("setResourceDeployStatus 2 with filter orange", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus deployed 2 - should filter resource", () => {
@@ -3612,11 +3708,19 @@ describe("setResourceDeployStatus 3 ", () => {
       }
     },
     specs: {
-      serviceModel: {
-        service1: {
-          cluster: "someOtherCluster",
-          status: "Failed"
+      raw: {
+        metadata: {
+          namespace: "default"
         }
+      },
+      serviceModel: {
+        "service1-braveman": [
+          {
+            namespace: "default",
+            cluster: "braveman",
+            status: "Failed"
+          }
+        ]
       }
     }
   };
@@ -3624,16 +3728,20 @@ describe("setResourceDeployStatus 3 ", () => {
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
-    { labelValue: "braveman", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "braveman" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
-    { labelValue: "possiblereptile", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
-    { labelValue: "sharingpenguin", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "sharingpenguin" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
-    { labelValue: "relievedox", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "relievedox" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
-  it("setResourceDeployStatus deployed 3", () => {
+  it("shows resources as not deployed", () => {
     expect(setResourceDeployStatus(node, [], {})).toEqual(result);
   });
 });
@@ -3648,6 +3756,7 @@ describe("setPlacementRuleDeployStatus 1 ", () => {
     specs: {
       raw: {
         metadata: {
+          namespace: "default",
           selfLink: "aaa"
         },
         spec: {
@@ -4019,7 +4128,9 @@ describe("setPodDeployStatus  with pod less then desired", () => {
       }
     },
     podStatusMap: {
-      possiblereptile: {
+      "possiblereptile-default": {
+        cluster: "possiblereptile",
+        namespace: "default",
         ready: 1,
         desired: 3,
         unavailable: 2
@@ -4028,6 +4139,9 @@ describe("setPodDeployStatus  with pod less then desired", () => {
     specs: {
       raw: {
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           replicas: 1,
           template: {
             spec: {
@@ -4037,20 +4151,32 @@ describe("setPodDeployStatus  with pod less then desired", () => {
         }
       },
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": {
-          cluster: "possiblereptile",
-          status: "err"
-        }
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "err"
+          }
+        ]
       }
     }
   };
   const result = [
     { type: "spacer" },
     { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "possiblereptile", status: "failure", value: "1/3" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "failure", value: "1/3" },
     { type: "spacer" },
     { type: "spacer" },
     { labelValue: "Pod details for {0}", type: "label" },
+    {
+      type: "label",
+      labelKey: "resource.namespace",
+      labelValue: undefined,
+      value: "default",
+      indent: undefined,
+      status: undefined
+    },
     {
       indent: undefined,
       labelKey: "resource.status",
@@ -4066,7 +4192,7 @@ describe("setPodDeployStatus  with pod less then desired", () => {
         data: {
           action: "show_resource_yaml",
           cluster: "possiblereptile",
-          editLink: "/resources?cluster=possiblereptile"
+          editLink: "/resources?cluster=possiblereptile&namespace=default"
         },
         label: "View Pod YAML and Logs"
       }
@@ -4124,6 +4250,7 @@ describe("setPodDeployStatus  with pod but no pod model and no podStatusMap", ()
     specs: {
       raw: {
         spec: {
+          metadata: "default",
           replicas: 1,
           template: {
             spec: {
@@ -4137,7 +4264,8 @@ describe("setPodDeployStatus  with pod but no pod model and no podStatusMap", ()
   const result = [
     { type: "spacer" },
     { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "possiblereptile", status: "pending", value: "Not Deployed" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("setPodDeployStatus with pod but no pod podStatusMap ", () => {
@@ -4165,7 +4293,9 @@ describe("setPodDeployStatus  with pod as desired", () => {
       }
     },
     podStatusMap: {
-      possiblereptile: {
+      "possiblereptile-default": {
+        namespace: "default",
+        cluster: "possiblereptile",
         ready: 3,
         desired: 3
       }
@@ -4181,32 +4311,53 @@ describe("setPodDeployStatus  with pod as desired", () => {
         }
       },
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": {
-          cluster: "possiblereptile",
-          status: "Running"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile2": {
-          cluster: "possiblereptile",
-          status: "Pending"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": {
-          cluster: "possiblereptile",
-          status: "CrashLoopBackOff"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": {
-          cluster: "possiblereptile4",
-          status: "CrashLoopBackOff"
-        }
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "Running"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile2": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "Pending"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "CrashLoopBackOff"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": [
+          {
+            cluster: "possiblereptile4",
+            namespace: "default",
+            status: "CrashLoopBackOff"
+          }
+        ]
       }
     }
   };
   const result = [
     { type: "spacer" },
     { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "possiblereptile", status: "checkmark", value: "3/3" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "checkmark", value: "3/3" },
     { type: "spacer" },
     { type: "spacer" },
     { labelValue: "Pod details for {0}", type: "label" },
+    {
+      type: "label",
+      labelKey: "resource.namespace",
+      labelValue: undefined,
+      value: "default",
+      indent: undefined,
+      status: undefined
+    },
     {
       indent: undefined,
       labelKey: "resource.status",
@@ -4222,7 +4373,7 @@ describe("setPodDeployStatus  with pod as desired", () => {
         data: {
           action: "show_resource_yaml",
           cluster: "possiblereptile",
-          editLink: "/resources?cluster=possiblereptile"
+          editLink: "/resources?cluster=possiblereptile&namespace=default"
         },
         label: "View Pod YAML and Logs"
       }
@@ -4253,6 +4404,14 @@ describe("setPodDeployStatus  with pod as desired", () => {
     },
     { type: "spacer" },
     {
+      type: "label",
+      labelKey: "resource.namespace",
+      labelValue: undefined,
+      value: "default",
+      indent: undefined,
+      status: undefined
+    },
+    {
       indent: undefined,
       labelKey: "resource.status",
       labelValue: undefined,
@@ -4267,7 +4426,7 @@ describe("setPodDeployStatus  with pod as desired", () => {
         data: {
           action: "show_resource_yaml",
           cluster: "possiblereptile",
-          editLink: "/resources?cluster=possiblereptile"
+          editLink: "/resources?cluster=possiblereptile&namespace=default"
         },
         label: "View Pod YAML and Logs"
       }
@@ -4323,7 +4482,8 @@ describe("setPodDeployStatus - pod as desired with green filter", () => {
       }
     },
     podStatusMap: {
-      possiblereptile: {
+      "possiblereptile-default": {
+        namespace: "default",
         ready: 3,
         desired: 3
       }
@@ -4333,6 +4493,9 @@ describe("setPodDeployStatus - pod as desired with green filter", () => {
         kind: "Pod",
         apiVersion: "v1",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           template: {
             spec: {
               containers: [{ c1: "aa" }]
@@ -4341,22 +4504,34 @@ describe("setPodDeployStatus - pod as desired with green filter", () => {
         }
       },
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": {
-          cluster: "possiblereptile",
-          status: "Running"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile2": {
-          cluster: "possiblereptile",
-          status: "Pending"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": {
-          cluster: "possiblereptile",
-          status: "CrashLoopBackOff"
-        },
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile4": {
-          cluster: "possiblereptile4",
-          status: "CrashLoopBackOff"
-        }
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "Running"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile2": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "Pending"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile3": [
+          {
+            cluster: "possiblereptile",
+            namespace: "default",
+            status: "CrashLoopBackOff"
+          }
+        ],
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile4": [
+          {
+            cluster: "possiblereptile4",
+            namespace: "default",
+            status: "CrashLoopBackOff"
+          }
+        ]
       }
     }
   };
@@ -4366,10 +4541,19 @@ describe("setPodDeployStatus - pod as desired with green filter", () => {
   const result = [
     { type: "spacer" },
     { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "possiblereptile", status: "checkmark", value: "3/3" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", status: "checkmark", value: "3/3" },
     { type: "spacer" },
     { type: "spacer" },
     { labelValue: "Pod details for {0}", type: "label" },
+    {
+      type: "label",
+      labelKey: "resource.namespace",
+      labelValue: undefined,
+      value: "default",
+      indent: undefined,
+      status: undefined
+    },
     {
       indent: undefined,
       labelKey: "resource.status",
@@ -4385,7 +4569,7 @@ describe("setPodDeployStatus - pod as desired with green filter", () => {
         data: {
           action: "show_resource_yaml",
           cluster: "possiblereptile",
-          editLink: "/resources?cluster=possiblereptile"
+          editLink: "/resources?cluster=possiblereptile&namespace=default"
         },
         label: "View Pod YAML and Logs"
       }
@@ -4441,7 +4625,9 @@ describe("setPodDeployStatus  with pod as desired", () => {
       }
     },
     podStatusMap: {
-      possiblereptile: {
+      "possiblereptile-default2": {
+        cluster: "possiblereptile2",
+        namespace: "default",
         ready: 1,
         desired: 1
       }
@@ -4449,6 +4635,9 @@ describe("setPodDeployStatus  with pod as desired", () => {
     specs: {
       raw: {
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           template: {
             spec: {
               containers: [{ c1: "aa" }]
@@ -4457,17 +4646,21 @@ describe("setPodDeployStatus  with pod as desired", () => {
         }
       },
       podModel: {
-        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile2": {
-          cluster: "possiblereptile2",
-          status: "Running"
-        }
+        "mortgage-app-deploy-55c65b9c8f-r84f4-possiblereptile": [
+          {
+            cluster: "possiblereptile2",
+            namespace: "default",
+            status: "Running"
+          }
+        ]
       }
     }
   };
   const result = [
     { type: "spacer" },
     { labelKey: "resource.deploy.pods.statuses", type: "label" },
-    { labelValue: "possiblereptile", status: "checkmark", value: "1/1" },
+    { labelValue: "Cluster name", value: "possiblereptile" },
+    { labelValue: "default", value: "Not Deployed", status: "pending" },
     { type: "spacer" }
   ];
   it("setPodDeployStatus with pod as desired but no matched cluster", () => {
@@ -4497,12 +4690,18 @@ describe("addNodeOCPRouteLocationForCluster no host spec", () => {
     },
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
-        kind: "Route"
+        kind: "Route",
+        metadata: {
+          namespace: "default"
+        }
       }
     }
   };
@@ -4546,14 +4745,20 @@ describe("addOCPRouteLocation spec no tls", () => {
     },
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            kind: "route",
+            namespace: "default",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           host: "1.1.1"
         }
       }
@@ -4561,7 +4766,9 @@ describe("addOCPRouteLocation spec no tls", () => {
   };
   const result = [];
   it("addOCPRouteLocation no tls", () => {
-    expect(addOCPRouteLocation(node, "possiblereptile", [])).toEqual(result);
+    expect(addOCPRouteLocation(node, "possiblereptile", "default", [])).toEqual(
+      result
+    );
   });
 });
 
@@ -4575,14 +4782,20 @@ describe("addNodeOCPRouteLocationForCluster spec no route", () => {
 
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           host: "1.1.1"
         }
       }
@@ -4606,14 +4819,20 @@ describe("addOCPRouteLocation spec with tls", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-route--route--mortgage-app-deploy",
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           tls: {},
           host: "1.1.1"
         }
@@ -4621,7 +4840,9 @@ describe("addOCPRouteLocation spec with tls", () => {
     }
   };
   it("addOCPRouteLocation with tls", () => {
-    expect(addOCPRouteLocation(node, "possiblereptile", [])).toEqual([]);
+    expect(addOCPRouteLocation(node, "possiblereptile", "default", [])).toEqual(
+      []
+    );
   });
 });
 
@@ -4634,14 +4855,20 @@ describe("addNodeOCPRouteLocationForCluster", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-route--route--mortgage-app-deploy",
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           tls: {},
           host: "1.1.1"
         }
@@ -4667,14 +4894,20 @@ describe("addNodeOCPRouteLocationForCluster", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-route--route--mortgage-app-deploy",
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           tls: {},
           host: "1.1.1"
         }
@@ -4724,10 +4957,13 @@ describe("addNodeOCPRouteLocationForCluster", () => {
     },
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
@@ -4783,14 +5019,20 @@ describe("addNodeOCPRouteLocationForCluster", () => {
     },
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           rules: [{}, {}]
         }
       }
@@ -4827,14 +5069,20 @@ describe("addNodeOCPRouteLocationForCluster", () => {
     },
     specs: {
       routeModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          kind: "route",
-          cluster: "possiblereptile"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            kind: "route",
+            cluster: "possiblereptile"
+          }
+        ]
       },
       raw: {
         kind: "Route",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           rules: [
             {
               route: "aaa"
@@ -4880,6 +5128,9 @@ describe("addIngressNodeInfo 1", () => {
       raw: {
         kind: "Ingress",
         spec: {
+          metadata: {
+            namespace: "default"
+          },
           rules: [
             {
               host: "aaa",
@@ -4954,6 +5205,9 @@ describe("addIngressNodeInfo other node type", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy",
     specs: {
       raw: {
+        metadata: {
+          namespace: "default"
+        },
         kind: "Ingress22"
       }
     }
@@ -4972,13 +5226,17 @@ describe("addNodeServiceLocation 1", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy",
     specs: {
       serviceModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          clusterIP: "1.1",
-          port: "80:65/TCP"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            clusterIP: "1.1",
+            port: "80:65/TCP"
+          }
+        ]
       },
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         kind: "Service",
@@ -4991,7 +5249,9 @@ describe("addNodeServiceLocation 1", () => {
   };
   const result = [{ labelKey: "raw.spec.host.location", value: "1.1:80" }];
   it("addNodeServiceLocation 1", () => {
-    expect(addNodeServiceLocation(node, "possiblereptile", [])).toEqual(result);
+    expect(
+      addNodeServiceLocation(node, "possiblereptile", "default", [])
+    ).toEqual(result);
   });
 });
 
@@ -5004,13 +5264,17 @@ describe("addNodeInfoPerCluster 1", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy",
     specs: {
       serviceModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          clusterIP: "1.1",
-          port: "80:65/TCP"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            clusterIP: "1.1",
+            port: "80:65/TCP"
+          }
+        ]
       },
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         kind: "Service",
@@ -5029,9 +5293,9 @@ describe("addNodeInfoPerCluster 1", () => {
     };
   });
   it("addNodeInfoPerCluster 1", () => {
-    expect(addNodeInfoPerCluster(node, "possiblereptile", [], testFn)).toEqual(
-      []
-    );
+    expect(
+      addNodeInfoPerCluster(node, "possiblereptile", "default", [], testFn)
+    ).toEqual([]);
   });
 });
 
@@ -5044,13 +5308,17 @@ describe("addNodeServiceLocationForCluster 1", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy",
     specs: {
       serviceModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          clusterIP: "1.1",
-          port: "80:65/TCP"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            clusterIP: "1.1",
+            port: "80:65/TCP"
+          }
+        ]
       },
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         kind: "Service",
@@ -5090,13 +5358,17 @@ describe("addNodeServiceLocationForCluster 1", () => {
       "member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy",
     specs: {
       serviceModel: {
-        "mortgage-app-deploy-possiblereptile": {
-          clusterIP: "1.1",
-          port: "80:65/TCP"
-        }
+        "mortgage-app-deploy-possiblereptile": [
+          {
+            namespace: "default",
+            clusterIP: "1.1",
+            port: "80:65/TCP"
+          }
+        ]
       },
       raw: {
         metadata: {
+          namespace: "default",
           name: "mortgage-app-deploy"
         },
         kind: "Service",

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -1414,11 +1414,13 @@ describe("setSubscriptionDeployStatus with time window ", () => {
     apiversion: "apps.open-cluster-management.io/v1",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Failed",
-          _hubClusterResource: "true"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Failed",
+            _hubClusterResource: "true"
+          }
+        ]
       },
       raw: {
         apiversion: "apps.open-cluster-management.io/v1",
@@ -1483,11 +1485,13 @@ describe("setSubscriptionDeployStatus with local hub subscription error ", () =>
     apiversion: "test",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Failed",
-          _hubClusterResource: "true"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Failed",
+            _hubClusterResource: "true"
+          }
+        ]
       },
       raw: {
         apiVersion: "test",
@@ -1532,11 +1536,13 @@ describe("setSubscriptionDeployStatus with hub error", () => {
     namespace: "ns",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Failed",
-          _hubClusterResource: "true"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Failed",
+            _hubClusterResource: "true"
+          }
+        ]
       }
     }
   };
@@ -1570,7 +1576,7 @@ describe("setSubscriptionDeployStatus with no sub error", () => {
     name: "name",
     namespace: "ns",
     specs: {
-      subscriptionModel: {}
+      subscriptionModel: []
     }
   };
   const response = [
@@ -1608,15 +1614,19 @@ describe("setSubscriptionDeployStatus with error", () => {
     namespace: "ns",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Failed"
-        },
-        sub2: {
-          cluster: "local",
-          status: "Propagated",
-          _hubClusterResource: true
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Failed"
+          }
+        ],
+        sub2: [
+          {
+            cluster: "local",
+            status: "Propagated",
+            _hubClusterResource: true
+          }
+        ]
       }
     }
   };
@@ -1652,10 +1662,12 @@ describe("setSubscriptionDeployStatus with hub no status", () => {
     namespace: "ns",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          _hubClusterResource: "true"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            _hubClusterResource: "true"
+          }
+        ]
       }
     }
   };
@@ -1695,14 +1707,18 @@ describe("setSubscriptionDeployStatus with remote no status", () => {
     namespace: "ns",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Propagated",
-          _hubClusterResource: "true"
-        },
-        sub2: {
-          cluster: "remote1"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Propagated",
+            _hubClusterResource: "true"
+          }
+        ],
+        sub2: [
+          {
+            cluster: "remote1"
+          }
+        ]
       }
     }
   };
@@ -1742,7 +1758,7 @@ describe("setSubscriptionDeployStatus for details yellow", () => {
     name: "name",
     namespace: "ns",
     specs: {
-      subscriptionModel: {}
+      subscriptionModel: []
     }
   };
   const response = [
@@ -1780,15 +1796,19 @@ describe("setSubscriptionDeployStatus for node type different then subscription 
     namespace: "ns",
     specs: {
       subscriptionModel: {
-        sub1: {
-          cluster: "local",
-          status: "Failed"
-        },
-        sub2: {
-          cluster: "local-cluster",
-          status: "Failed",
-          name: "sub2-local"
-        }
+        sub1: [
+          {
+            cluster: "local",
+            status: "Failed"
+          }
+        ],
+        sub2: [
+          {
+            cluster: "local-cluster",
+            status: "Failed",
+            name: "sub2-local"
+          }
+        ]
       }
     }
   };
@@ -1822,7 +1842,7 @@ describe("setupResourceModel undefined 2", () => {
 });
 
 describe("computeNodeStatus ", () => {
-  const subscriptionInputGreen = {
+  const subscriptionInputRed1 = {
     id: "member--subscription--default--mortgagedc-subscription",
     name: "mortgagedc",
     specs: {
@@ -1830,34 +1850,38 @@ describe("computeNodeStatus ", () => {
         spec: { template: { spec: { containers: [{ name: "c1" }] } } }
       },
       subscriptionModel: {
-        "mortgagedc-subscription-braveman": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "Subscribed",
-          _clusterNamespace: "braveman-ns"
-        },
-        "mortgagedc-subscription-braveman2": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman2",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "SubscribedFailed",
-          _clusterNamespace: "braveman-ns"
-        }
+        "mortgagedc-subscription-braveman": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "Subscribed",
+            _clusterNamespace: "braveman-ns"
+          }
+        ],
+        "mortgagedc-subscription-braveman2": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman2",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "SubscribedFailed",
+            _clusterNamespace: "braveman-ns"
+          }
+        ]
       },
       row: 12
     },
@@ -1882,34 +1906,38 @@ describe("computeNodeStatus ", () => {
         spec: { template: { spec: { containers: [{ name: "c1" }] } } }
       },
       subscriptionModel: {
-        "mortgagedc-subscription-braveman": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "Subscribed",
-          _clusterNamespace: "braveman-ns"
-        },
-        "mortgagedc-subscription-braveman2": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman2",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "SomeOtherState",
-          _clusterNamespace: "braveman-ns"
-        }
+        "mortgagedc-subscription-braveman": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "Subscribed",
+            _clusterNamespace: "braveman-ns"
+          }
+        ],
+        "mortgagedc-subscription-braveman2": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman2",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "SomeOtherState",
+            _clusterNamespace: "braveman-ns"
+          }
+        ]
       },
       row: 12
     },
@@ -1923,7 +1951,7 @@ describe("computeNodeStatus ", () => {
       raw: {
         spec: { template: { spec: { containers: [{ name: "c1" }] } } }
       },
-      subscriptionModel: {},
+      subscriptionModel: [],
       row: 12
     },
     type: "subscription"
@@ -1937,34 +1965,38 @@ describe("computeNodeStatus ", () => {
         spec: { template: { spec: { containers: [{ name: "c1" }] } } }
       },
       subscriptionModel: {
-        "mortgagedc-subscription-braveman": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "Subscribed",
-          _clusterNamespace: "braveman-ns"
-        },
-        "mortgagedc-subscription-braveman2": {
-          apigroup: "apps.open-cluster-management.io",
-          apiversion: "v1",
-          channel: "mortgagedc-ch/mortgagedc-channel",
-          cluster: "braveman2",
-          created: "2020-04-20T22:02:46Z",
-          kind: "subscription",
-          label:
-            "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
-          name: "mortgagedc-subscription",
-          namespace: "default",
-          status: "Propagated",
-          _clusterNamespace: "braveman-ns"
-        }
+        "mortgagedc-subscription-braveman": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "Subscribed",
+            _clusterNamespace: "braveman-ns"
+          }
+        ],
+        "mortgagedc-subscription-braveman2": [
+          {
+            apigroup: "apps.open-cluster-management.io",
+            apiversion: "v1",
+            channel: "mortgagedc-ch/mortgagedc-channel",
+            cluster: "braveman2",
+            created: "2020-04-20T22:02:46Z",
+            kind: "subscription",
+            label:
+              "app=mortgagedc; hosting-deployable-name=mortgagedc-subscription-deployable; subscription-pause=false",
+            name: "mortgagedc-subscription",
+            namespace: "default",
+            status: "Propagated",
+            _clusterNamespace: "braveman-ns"
+          }
+        ]
       },
       row: 12
     },
@@ -2966,7 +2998,7 @@ describe("computeNodeStatus ", () => {
     specs: {}
   };
 
-  const appNoChannelRed1 = {
+  const appNoChannelGreen = {
     name: "mortgage-app-deploy",
     cluster: null,
     clusterName: null,
@@ -3048,11 +3080,11 @@ describe("computeNodeStatus ", () => {
     expect(computeNodeStatus(appNoChannelRed)).toEqual("red");
   });
 
-  it("return appNnoChannelRed1 green", () => {
-    expect(computeNodeStatus(appNoChannelRed1)).toEqual("green");
+  it("return appNoChannelGreen green", () => {
+    expect(computeNodeStatus(appNoChannelGreen)).toEqual("green");
   });
   it("return computeNodeStatus red", () => {
-    expect(computeNodeStatus(subscriptionInputGreen)).toEqual("red");
+    expect(computeNodeStatus(subscriptionInputRed1)).toEqual("red");
   });
 
   it("return computeNodeStatus orange", () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9286

Changes involved completely updating the resourceMap structure that holds the deployed resources
Until now we assumed that the key resourceType_resourceName_cluster points to one resource only
With Argo, it can point to multiple, if the Argo grouped apps deploy into the same cluster, different namespaces


<img width="954" alt="Screen Shot 2021-03-30 at 12 29 08 PM" src="https://user-images.githubusercontent.com/43010150/113221181-8ae26b00-9252-11eb-8fe3-10effdda4b51.png">
<img width="798" alt="Screen Shot 2021-03-30 at 4 15 18 PM" src="https://user-images.githubusercontent.com/43010150/113221201-933aa600-9252-11eb-8eb0-18a6e9e018a0.png">
