### PR TITLE
Fix too many svg text nodes created for Argo app count

### DIFF
--- a/src-web/components/Topology/viewer/helpers/nodeHelper.js
+++ b/src-web/components/Topology/viewer/helpers/nodeHelper.js
@@ -416,6 +416,9 @@ export default class NodeHelper {
       return layout.type === 'application'
     })
 
+    const argoAppCountTextNodes = argoAppNode.selectAll(gArgoAppCountText)
+    argoAppCountTextNodes.remove()
+
     argoAppNode
       .append('g')
       .attr('class', 'argoAppCountText')


### PR DESCRIPTION
Fixed the issue where too many svg text nodes are created for the Argo app count causing the text to look more bold than it should be:

Before:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/38960034/113348308-6c3cac80-9304-11eb-8dfe-7ca8c195001d.png">
<img width="1669" alt="image" src="https://user-images.githubusercontent.com/38960034/113348468-9a21f100-9304-11eb-9b11-6acd1fdd7053.png">

After:
<img width="649" alt="image" src="https://user-images.githubusercontent.com/38960034/113349769-8a0b1100-9306-11eb-8ed9-a7ae1accb03d.png">
<img width="1661" alt="image" src="https://user-images.githubusercontent.com/38960034/113349900-b757bf00-9306-11eb-957f-b0e7e3bb8269.png">
