### PR TITLE
address argo server mapping for non ocp clusters

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -454,12 +454,10 @@ export const updateAppClustersMatchingSearch = (node, searchClusters) => {
       if (clusterIdx !== -1) {
         const kubeClusterName = appCls.substring(clusterIdx + 9)
         // this is a non ocp cluster, server destination set by name
-        possibleMatch = _.find(searchClusters, cls =>
-          _.includes(
-            [kubeClusterName, `${kubeClusterName}-cluster`],
-            _.get(cls, 'name', '_')
-          )
-        )
+        possibleMatch = _.find(searchClusters, cls => {
+          const clsName = _.get(cls, 'name', '_')
+          return _.includes([clsName, `${clsName}-cluster`], kubeClusterName)
+        })
       } else {
         const clusterMatchName = _.startsWith(appCls, 'https://api.')
           ? clsUrl.hostname.substring(3)

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -81,7 +81,7 @@ export const getClusterName = (nodeId, node, findAll) => {
   if (node && _.get(node, 'clusters.id', '') === 'member--clusters--') {
     //cluster info is not set on the node id, get it from here
     if (findAll) {
-      //get all cluster names as set by argo target, ignore deplaybale status
+      //get all cluster names as set by argo target, ignore deployable status
       return _.union(
         _.get(node, 'specs.clustersNames', []),
         _.get(node, 'clusters.specs.appClusters', [])
@@ -444,22 +444,34 @@ export const getPulseStatusForArgoApp = node => {
 export const updateAppClustersMatchingSearch = (node, searchClusters) => {
   //get only clusters in a url format looking like a cluster api url
   const appClusters = _.get(node, 'specs.appClusters', [])
-  const appClustersUsingURL = _.filter(appClusters, cls =>
-    _.startsWith(cls, 'https://api.')
-  )
+  const appClustersUsingURL = _.filter(appClusters, cls => isValidHttpUrl(cls))
 
   appClustersUsingURL.forEach(appCls => {
     try {
+      let possibleMatch
       const clsUrl = new URL(appCls)
-      const clusterMatchName = clsUrl.hostname.substring(3) //remove api
-
-      const possibleMatch = _.find(searchClusters, cls =>
-        _.endsWith(_.get(cls, 'consoleURL', ''), clusterMatchName)
-      )
+      const clusterIdx = appCls.indexOf(':cluster/')
+      if (clusterIdx !== -1) {
+        const kubeClusterName = appCls.substring(clusterIdx + 9)
+        // this is a non ocp cluster, server destination set by name
+        possibleMatch = _.find(searchClusters, cls =>
+          _.includes(
+            [kubeClusterName, `${kubeClusterName}-cluster`],
+            _.get(cls, 'name', '_')
+          )
+        )
+      } else {
+        const clusterMatchName = _.startsWith(appCls, 'https://api.')
+          ? clsUrl.hostname.substring(3)
+          : 'unknown'
+        possibleMatch = _.find(searchClusters, cls =>
+          _.endsWith(_.get(cls, 'consoleURL', '_'), clusterMatchName)
+        )
+      }
+      _.pull(appClusters, appCls)
       if (possibleMatch) {
         //found the cluster matching the app destination server url, use the cluster name
         const matchedClusterName = _.get(possibleMatch, 'name', '')
-        _.pull(appClusters, appCls)
         if (!_.includes(appClusters, matchedClusterName)) {
           appClusters.push(matchedClusterName)
         }
@@ -478,4 +490,14 @@ export const updateAppClustersMatchingSearch = (node, searchClusters) => {
   _.set(node, 'specs.appClusters', _.sortBy(appClusters))
   _.set(node, 'specs.clusters', searchClusters)
   return node
+}
+
+export const isValidHttpUrl = value => {
+  let validUrl = true
+  try {
+    new URL(value)
+  } catch (err) {
+    validUrl = false
+  }
+  return validUrl
 }

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -46,11 +46,13 @@ describe("updateAppClustersMatchingSearch", () => {
         "https://api.app-abcd.managed_no_match.com:6999",
         "https://api.app-abcd.managed.com:6999",
         "https://ABCD.gr7.123.eks.amazonaws.com",
-        "abcd:aws:eks:123:456:cluster/fxiang-eks"
+        "abcd:aws:eks:123:456:cluster/fxiang-eks",
+        "abcd:aws:eks:123:456:cluster/fxiang-eks-cluster"
       ],
       targetNamespaces: {
         "https://ABCD.gr7.123.eks.amazonaws.com": ["default"],
         "abcd:aws:eks:123:456:cluster/fxiang-eks": ["helloworld-eks2"],
+        "abcd:aws:eks:123:456:cluster/fxiang-eks-cluster": ["helloworld-eks3"],
         "https://api.app-abcd.com:1234": ["localNS1", "localNS2"],
         "https://api.app-abcd.managed_no_match.com:6999": ["a", "b"],
         "https://api.app-abcd.managed.com:6999": ["namespace1", "namespace2"],
@@ -66,12 +68,13 @@ describe("updateAppClustersMatchingSearch", () => {
       targetNamespaces: {
         "https://ABCD.gr7.123.eks.amazonaws.com": ["default"],
         "abcd:aws:eks:123:456:cluster/fxiang-eks": ["helloworld-eks2"],
+        "abcd:aws:eks:123:456:cluster/fxiang-eks-cluster": ["helloworld-eks3"],
         "https://api.app-abcd.com:1234": ["localNS1", "localNS2"],
         "https://api.app-abcd.managed_no_match.com:6999": ["a", "b"],
         "https://api.app-abcd.managed.com:6999": ["namespace1", "namespace2"],
         "ui-managed": ["namespace1", "namespace2", "namespace3"],
         "local-cluster": ["localNS1", "localNS2", "namespace4"],
-        "fxiang-eks": ["helloworld-eks2"]
+        "fxiang-eks": ["helloworld-eks2", "helloworld-eks3"]
       }
     }
   };

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -28,6 +28,13 @@ describe("updateAppClustersMatchingSearch", () => {
     {
       name: "ui-managed",
       consoleURL: "https://console-openshift-console.apps.app-abcd.managed.com"
+    },
+    {
+      HubAcceptedManagedCluster: "True",
+      ManagedClusterConditionAvailable: "True",
+      kind: "cluster",
+      label: "cloud=Amazon; environment=Dev; name=fxiang-eks; vendor=EKS",
+      name: "fxiang-eks"
     }
   ];
   const clsNode1 = {
@@ -37,9 +44,13 @@ describe("updateAppClustersMatchingSearch", () => {
         "ui-managed",
         "https://api.app-abcd.com:1234",
         "https://api.app-abcd.managed_no_match.com:6999",
-        "https://api.app-abcd.managed.com:6999"
+        "https://api.app-abcd.managed.com:6999",
+        "https://ABCD.gr7.123.eks.amazonaws.com",
+        "abcd:aws:eks:123:456:cluster/fxiang-eks"
       ],
       targetNamespaces: {
+        "https://ABCD.gr7.123.eks.amazonaws.com": ["default"],
+        "abcd:aws:eks:123:456:cluster/fxiang-eks": ["helloworld-eks2"],
         "https://api.app-abcd.com:1234": ["localNS1", "localNS2"],
         "https://api.app-abcd.managed_no_match.com:6999": ["a", "b"],
         "https://api.app-abcd.managed.com:6999": ["namespace1", "namespace2"],
@@ -51,17 +62,16 @@ describe("updateAppClustersMatchingSearch", () => {
   const resultNode1 = {
     specs: {
       clusters: searchClusters,
-      appClusters: [
-        "https://api.app-abcd.managed_no_match.com:6999",
-        "local-cluster",
-        "ui-managed"
-      ],
+      appClusters: ["fxiang-eks", "local-cluster", "ui-managed"],
       targetNamespaces: {
+        "https://ABCD.gr7.123.eks.amazonaws.com": ["default"],
+        "abcd:aws:eks:123:456:cluster/fxiang-eks": ["helloworld-eks2"],
         "https://api.app-abcd.com:1234": ["localNS1", "localNS2"],
         "https://api.app-abcd.managed_no_match.com:6999": ["a", "b"],
         "https://api.app-abcd.managed.com:6999": ["namespace1", "namespace2"],
         "ui-managed": ["namespace1", "namespace2", "namespace3"],
-        "local-cluster": ["localNS1", "localNS2", "namespace4"]
+        "local-cluster": ["localNS1", "localNS2", "namespace4"],
+        "fxiang-eks": ["helloworld-eks2"]
       }
     }
   };

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -3202,16 +3202,16 @@ describe("setResourceDeployStatus 1 ", () => {
     { type: "label", labelKey: "resource.deploy.statuses" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "braveman" },
-    { labelValue: "", value: "Not Deployed", status: "pending" },
+    { labelValue: "default", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "possiblereptile" },
-    { labelValue: "", value: "Not Deployed", status: "pending" },
+    { labelValue: "default", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "sharingpenguin" },
-    { labelValue: "", value: "Not Deployed", status: "pending" },
+    { labelValue: "default", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "relievedox" },
-    { labelValue: "", value: "Not Deployed", status: "pending" },
+    { labelValue: "default", value: "Not Deployed", status: "pending" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus not deployed 1", () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11215

<img width="567" alt="Screen Shot 2021-04-08 at 2 24 34 PM" src="https://user-images.githubusercontent.com/43010150/114096108-4bd49b00-988c-11eb-826e-79eaf57a1f0d.png">
<img width="888" alt="Screen Shot 2021-04-08 at 2 53 23 PM" src="https://user-images.githubusercontent.com/43010150/114096109-4c6d3180-988c-11eb-8f12-f9a6dd9938b0.png">
<img width="879" alt="Screen Shot 2021-04-08 at 2 53 45 PM" src="https://user-images.githubusercontent.com/43010150/114096110-4c6d3180-988c-11eb-975f-8fe4fcdd88bf.png">
<img width="908" alt="Screen Shot 2021-04-08 at 1 54 35 PM" src="https://user-images.githubusercontent.com/43010150/114096144-54c56c80-988c-11eb-8045-44b2de0d08ca.png">

How the mapping works

- Step 0:
  - Get the list of ArgoApps
  - Build the list of target namespaces they deploy to 
  - Use search to retrieve all the clusters where these apps have deployed resources to; we keep this searchClusters list as the source of truth for deployed resources and to help with the argo server mapping.
So.. unless the ARGO target server uses the name of the cluster ( so no need for mapping from argo > cluster name ), we can’t identify Not Deployed resources for clusters not showing up in the search query; unless at least one resource was deployed there, that cluster is invisible

- Step 1, the actual mapping from ARGO server > cluster names: 
  - ARGO destination is a name - just use the name, the assumption is the name matches the corresponding cluster name, used to import the cluster on the hub
  - ARGO destination server is a valid URL
     - URL starts with https://api.  This is an OCP cluster  and the URL matches an OCP cluster apiURL. Match the apiURL with the consoleURL for any of the clusters retrieved using search in (step 0); if a cluster matches this apiURL, add the cluster name to the list of target clusters. 
     - URL doesn’t start with https://api ; not an OCP cluster. The variant I tested here was a EKS cluster ( we should test with others too )
       - If url contains :cluster/ , the assumption is that is a Kube context, in this format abcd:aws:eks:123:456:cluster/fxiang-eks, or abcd:aws:eks:123:456:cluster/fxiang-eks-cluster. Get the string after :cluster/ , which is fxiang-eks and try to find
       -  Everything else is unknown
       - Remove the apiURL from target cluster list, regardless if there was a match or not; this step is debatable .. if we don't remove the cluster, it is going to show up with no data linked to it ( since search doesn't know what cluster it maps to ), so there is no benefit to have a long url in the props dialog with nothing to tell about it
 


- Step 3, display resource status based on step 0, 1:
  - Loop through all the cluster found by search and any NOT covered by the mapping steps > these are the targetClusters
  - For each target cluster, get the target namespaces ( union of Argo namespaces and namespaces returned by search )
  - For each target namespace, show the selected resource status, using search query ; if resource type not found in that NS, show as Not Deployed
  - If a cluster is in the targetClusters but not having an active status, mark if offline 



