### PR TITLE
show not deployed status for missing argo clusters

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -387,6 +387,7 @@ resource.channels = Channels
 resource.cluster = Cluster
 resource.cluster.labels = Cluster selector
 resource.cluster.offline=Cluster is offline
+resource.cluster.notmapped = Could not locate a cluster for this URL. Using a cluster name when defining the Argo server destination could fix this issue.
 resource.clusterip=Cluster IP
 resource.clustername = Cluster
 resource.clusters = Clusters

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -468,7 +468,7 @@ export const updateAppClustersMatchingSearch = (node, searchClusters) => {
           _.endsWith(_.get(cls, 'consoleURL', '_'), clusterMatchName)
         )
       }
-      _.pull(appClusters, appCls)
+      _.pull(appClusters, appCls) //remove the URL cluster destination
       if (possibleMatch) {
         //found the cluster matching the app destination server url, use the cluster name
         const matchedClusterName = _.get(possibleMatch, 'name', '')
@@ -500,4 +500,37 @@ export const isValidHttpUrl = value => {
     validUrl = false
   }
   return validUrl
+}
+
+//show warning when no deployed resources are not found by search on this cluster name
+export const showMissingClusterDetails = (clusterName, node, details) => {
+  if (clusterName.length === 0 || isValidHttpUrl(clusterName)) {
+    // this cluster name could not be mapped to a cluster name
+    // search clusters mapping fails when there are no deployed resources or clusters not found..
+    if (clusterName.length === 0) {
+      const clsNames = Object.keys(
+        _.get(node, 'clusters.specs.targetNamespaces', { unknown: [] })
+      )
+      clsNames.forEach(clsName => {
+        details.push({
+          labelValue: clsName,
+          value: msgs.get('spec.deploy.not.deployed'),
+          status: pendingStatus
+        })
+      })
+    } else {
+      details.push({
+        labelValue: clusterName,
+        value: msgs.get('resource.cluster.notmapped'),
+        status: pendingStatus
+      })
+    }
+  } else {
+    details.push({
+      labelValue: clusterName,
+      value: msgs.get('resource.cluster.offline'),
+      status: warningStatus
+    })
+  }
+  return details
 }


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11215

If an argo app has no deployed resources, the cluster deploy status is empty
Fixed to show the list of target clusters from target ns map - in this case search is not returning any cluster

<img width="753" alt="Screen Shot 2021-04-09 at 11 07 16 AM" src="https://user-images.githubusercontent.com/43010150/114207918-e4215d00-992a-11eb-91f8-fe17ce858e1d.png">

<img width="806" alt="Screen Shot 2021-04-09 at 11 42 39 AM" src="https://user-images.githubusercontent.com/43010150/114207893-dc61b880-992a-11eb-97d3-085bdca2c472.png">
<img width="739" alt="Screen Shot 2021-04-09 at 11 07 55 AM" src="https://user-images.githubusercontent.com/43010150/114207905-e08dd600-992a-11eb-8dba-74e746ce6911.png">
