### PR TITLE
argo app doesn't show not deployed status for ocp clusters

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -510,7 +510,19 @@ export const isValidHttpUrl = value => {
 
 //show warning when no deployed resources are not found by search on this cluster name
 export const showMissingClusterDetails = (clusterName, node, details) => {
-  if (isValidHttpUrl(clusterName)) {
+  if (clusterName.length === 0) {
+    // there are no deployed clusters for this app group
+    const clsNames = Object.keys(
+      _.get(node, 'clusters.specs.targetNamespaces', { unknown: [] })
+    )
+    clsNames.forEach(clsName => {
+      details.push({
+        labelValue: clsName,
+        value: msgs.get('spec.deploy.not.deployed'),
+        status: pendingStatus
+      })
+    })
+  } else if (isValidHttpUrl(clusterName)) {
     // this cluster name could not be mapped to a cluster name
     // search clusters mapping fails when there are no deployed resources or clusters not found..
     if (_.startsWith(clusterName, 'https://api.')) {
@@ -519,17 +531,6 @@ export const showMissingClusterDetails = (clusterName, node, details) => {
         labelValue: clusterName,
         value: msgs.get('spec.deploy.not.deployed'),
         status: pendingStatus
-      })
-    } else if (clusterName.length === 0) {
-      const clsNames = Object.keys(
-        _.get(node, 'clusters.specs.targetNamespaces', { unknown: [] })
-      )
-      clsNames.forEach(clsName => {
-        details.push({
-          labelValue: clsName,
-          value: msgs.get('spec.deploy.not.deployed'),
-          status: pendingStatus
-        })
       })
     } else {
       details.push({

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -452,6 +452,7 @@ export const updateAppClustersMatchingSearch = (node, searchClusters) => {
     try {
       let possibleMatch
       const clsUrl = new URL(appCls)
+      const isOCPUrl = _.startsWith(clsUrl.hostname, 'api')
       const clusterIdx = appCls.indexOf(':cluster/')
       if (clusterIdx !== -1) {
         const kubeClusterName = appCls.substring(clusterIdx + 9)
@@ -461,14 +462,19 @@ export const updateAppClustersMatchingSearch = (node, searchClusters) => {
           return _.includes([clsName, `${clsName}-cluster`], kubeClusterName)
         })
       } else {
-        const clusterMatchName = _.startsWith(appCls, 'https://api.')
-          ? clsUrl.hostname.substring(3)
-          : 'unknown'
-        possibleMatch = _.find(searchClusters, cls =>
-          _.endsWith(_.get(cls, 'consoleURL', '_'), clusterMatchName)
-        )
+        if (isOCPUrl) {
+          possibleMatch = _.find(searchClusters, cls =>
+            _.endsWith(
+              _.get(cls, 'consoleURL', '_'),
+              clsUrl.hostname.substring(3)
+            )
+          )
+        }
       }
-      _.pull(appClusters, appCls) //remove the URL cluster destination
+      if (possibleMatch || !isOCPUrl) {
+        // remove the URL cluster destination only for matched clusters or non ocp clusters
+        _.pull(appClusters, appCls)
+      }
       if (possibleMatch) {
         //found the cluster matching the app destination server url, use the cluster name
         const matchedClusterName = _.get(possibleMatch, 'name', '')
@@ -504,10 +510,17 @@ export const isValidHttpUrl = value => {
 
 //show warning when no deployed resources are not found by search on this cluster name
 export const showMissingClusterDetails = (clusterName, node, details) => {
-  if (clusterName.length === 0 || isValidHttpUrl(clusterName)) {
+  if (isValidHttpUrl(clusterName)) {
     // this cluster name could not be mapped to a cluster name
     // search clusters mapping fails when there are no deployed resources or clusters not found..
-    if (clusterName.length === 0) {
+    if (_.startsWith(clusterName, 'https://api.')) {
+      // ocp cluster, mapping not found which means there is no deployment on this cluster
+      details.push({
+        labelValue: clusterName,
+        value: msgs.get('spec.deploy.not.deployed'),
+        status: pendingStatus
+      })
+    } else if (clusterName.length === 0) {
       const clsNames = Object.keys(
         _.get(node, 'clusters.specs.targetNamespaces', { unknown: [] })
       )

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -723,7 +723,7 @@ export const setClusterStatus = (node, details) => {
       //target cluster not deployed on
       clusterArr.push({
         name: appCls,
-        namespace: appCls === LOCAL_HUB_NAME ? appCls : '',
+        _clusterNamespace: appCls === LOCAL_HUB_NAME ? appCls : '_',
         status: appCls === LOCAL_HUB_NAME ? 'ok' : ''
       })
     }

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -64,7 +64,12 @@ describe("updateAppClustersMatchingSearch", () => {
   const resultNode1 = {
     specs: {
       clusters: searchClusters,
-      appClusters: ["fxiang-eks", "local-cluster", "ui-managed"],
+      appClusters: [
+        "fxiang-eks",
+        "https://api.app-abcd.managed_no_match.com:6999",
+        "local-cluster",
+        "ui-managed"
+      ],
       targetNamespaces: {
         "https://ABCD.gr7.123.eks.amazonaws.com": ["default"],
         "abcd:aws:eks:123:456:cluster/fxiang-eks": ["helloworld-eks2"],

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -343,6 +343,7 @@
   "resource.cluster": "Cluster",
   "resource.cluster.labels": "Cluster selector",
   "resource.cluster.offline": "Cluster is offline",
+  "resource.cluster.notmapped": "Could not locate a cluster for this URL. Using a cluster name when defining the Argo server destination could fix this issue.",
   "resource.clusterip": "Cluster IP",
   "resource.clustername": "Cluster",
   "resource.clusters": "Clusters",


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11215

If a remote ocp cluster has no deployment for any of the grouped argo applications, the properties dialog doesn't show the missed cluster
This is because the mapping doesn't find a matching cluster among the clusters returned by search so it assumes it's an unknown (eks) cluster, which are not reported as not deployed

Fix below

<img width="956" alt="Screen Shot 2021-04-09 at 2 29 18 PM" src="https://user-images.githubusercontent.com/43010150/114225455-52244f00-9940-11eb-9463-29b940d7ddc1.png">
