### PR TITLE
change links to the targeted application

### DIFF
--- a/src-web/components/common/OverviewCards/index.js
+++ b/src-web/components/common/OverviewCards/index.js
@@ -125,8 +125,7 @@ class OverviewCards extends React.Component {
 
     const targetLink = getSearchLinkForOneApplication({
       name: encodeURIComponent(selectedAppName),
-      namespace: encodeURIComponent(selectedAppNS),
-      cluster: encodeURIComponent(deployedCluster)
+      namespace: encodeURIComponent(selectedAppNS)
     })
 
     const appOverviewCardsData = getAppOverviewCardsData(
@@ -324,7 +323,14 @@ class OverviewCards extends React.Component {
                   )}
                 </AcmButton>
                 <AcmButton
-                  href={getUrl + appOverviewCardsData.targetLink}
+                  href={
+                    getUrl +
+                    this.getArgoSearchLink(
+                      selectedAppName,
+                      selectedAppNS,
+                      deployedCluster
+                    )
+                  }
                   variant={ButtonVariant.link}
                   id="app-search-link"
                   component="a"
@@ -394,6 +400,14 @@ class OverviewCards extends React.Component {
       </div>
     )
   }
+
+  getArgoSearchLink = (selectedAppName, selectedAppNS, deployedCluster) => {
+    return getSearchLinkForOneApplication({
+      name: encodeURIComponent(selectedAppName),
+      namespace: encodeURIComponent(selectedAppNS),
+      cluster: encodeURIComponent(deployedCluster)
+    })
+  };
 
   renderData = (checkData, showData, width) => {
     return checkData !== -1 ? (

--- a/src-web/components/common/OverviewCards/index.js
+++ b/src-web/components/common/OverviewCards/index.js
@@ -107,6 +107,9 @@ class OverviewCards extends React.Component {
       locale
     } = this.props
     const { argoLinkLoading, showSubCards } = this.state
+    const deployedCluster =
+      _.get(topology, 'activeFilters.application.cluster') ||
+      _.get(HCMApplicationList, 'items[0].cluster')
 
     if (HCMApplicationList.status === REQUEST_STATUS.NOT_FOUND) {
       const infoMessage = _.get(
@@ -122,7 +125,8 @@ class OverviewCards extends React.Component {
 
     const targetLink = getSearchLinkForOneApplication({
       name: encodeURIComponent(selectedAppName),
-      namespace: encodeURIComponent(selectedAppNS)
+      namespace: encodeURIComponent(selectedAppNS),
+      cluster: encodeURIComponent(deployedCluster)
     })
 
     const appOverviewCardsData = getAppOverviewCardsData(
@@ -305,7 +309,7 @@ class OverviewCards extends React.Component {
                   onClick={() =>
                     // launch a new tab to argocd route
                     openArgoCDEditor(
-                      appOverviewCardsData.clusterNames,
+                      deployedCluster,
                       selectedAppNS,
                       selectedAppName,
                       this.toggleArgoLinkLoading,

--- a/src-web/components/common/OverviewCards/index.js
+++ b/src-web/components/common/OverviewCards/index.js
@@ -107,10 +107,11 @@ class OverviewCards extends React.Component {
       locale
     } = this.props
     const { argoLinkLoading, showSubCards } = this.state
+    const items = _.get(HCMApplicationList, 'items', [])
     const deployedCluster =
       _.get(topology, 'activeFilters.application.cluster') ||
-      _.get(HCMApplicationList, 'items[0].cluster')
-
+      (items.length ? _.get(items[0], 'cluster') : null) ||
+      null
     if (HCMApplicationList.status === REQUEST_STATUS.NOT_FOUND) {
       const infoMessage = _.get(
         HCMApplicationList,

--- a/src-web/components/common/ResourceOverview/utils.js
+++ b/src-web/components/common/ResourceOverview/utils.js
@@ -16,10 +16,11 @@ export const getSearchLinkForOneApplication = params => {
     const namespace = params.namespace
       ? `%20namespace%3A${params.namespace}`
       : ''
+    const cluster = params.cluster ? `%20cluster%3A${params.cluster}` : ''
     const showRelated = params.showRelated
       ? `&showrelated=${params.showRelated}`
       : ''
-    return `/search?filters={"textsearch":"kind%3Aapplication${name}${namespace}"}${showRelated}`
+    return `/search?filters={"textsearch":"kind%3Aapplication${name}${namespace}${cluster}"}${showRelated}`
   }
   return ''
 }

--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -404,7 +404,7 @@ export const validateTopology = (
     .invoke("attr", "href")
     .should(
       "include",
-      `search?filters={"textsearch":"kind%3Aapplication%20name%3A${name}%20namespace%3A${namespace}"}`
+      `search?filters={"textsearch":"kind%3Aapplication%20name%3A${name}%20namespace%3A${namespace}`
     );
 
   if (type === "argo") {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11402
For argocd applications:
- search resource will now have cluster parameter

![image](https://user-images.githubusercontent.com/26282541/114606708-9b8adc00-9c69-11eb-9bdb-ba0f76ef5680.png)

- Launch Argo editor will now launch to the the cluster of the selected app

**local**
![image](https://user-images.githubusercontent.com/26282541/114608380-a21a5300-9c6b-11eb-9b40-af27786f8305.png)
![image](https://user-images.githubusercontent.com/26282541/114608579-d4c44b80-9c6b-11eb-8828-bf99ac44859a.png)

**ui-managed**

![image](https://user-images.githubusercontent.com/26282541/114608685-ee659300-9c6b-11eb-8548-524195fd79d8.png)
![image](https://user-images.githubusercontent.com/26282541/114608755-0210f980-9c6c-11eb-994a-1e4017dfc569.png)
