### PR TITLE
use initial refresh time

### DIFF
--- a/lib/shared/constants.js
+++ b/lib/shared/constants.js
@@ -25,6 +25,7 @@ module.exports.DIAGRAM_REFRESH_INTERVAL_COOKIE =
   'mcm-diagram-interval-refresh-cookie'
 module.exports.REFRESH_TIMES = [15, 30, 60, 5 * 60, 30 * 60, 0]
 module.exports.DEFAULT_REFRESH_TIME = 15000
+module.exports.INITIAL_REFRESH_TIME = 15
 
 module.exports.OVERVIEW_QUERY_COOKIE = 'mcm-overview-query-cookie'
 module.exports.OVERVIEW_STATE_COOKIE = 'mcm-overview-state-cookie'

--- a/src-web/components/common/AutoRefreshSelect.js
+++ b/src-web/components/common/AutoRefreshSelect.js
@@ -14,9 +14,9 @@ import {
 
 import { getSelectedId } from './QuerySwitcher'
 import {
+  INITIAL_REFRESH_TIME,
   RESOURCE_TYPES,
-  REFRESH_TIMES,
-  DEFAULT_REFRESH_TIME
+  REFRESH_TIMES
 } from '../../../lib/shared/constants'
 import { fetchResources } from '../../actions/common'
 import { combineFilters } from '../../actions/filters'
@@ -83,7 +83,7 @@ class AutoRefreshSelect extends Component {
           <AcmAutoRefreshSelect
             refetch={refetch}
             refreshIntervals={REFRESH_TIMES}
-            pollInterval={DEFAULT_REFRESH_TIME}
+            initRefreshTime={INITIAL_REFRESH_TIME}
           />
         )}
         {!isEditTab && (


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10369
The default refresh time will be 15s. The user can change the default time by selecting the dropdown and the new value will be saved.