### PR TITLE
show warning status if one ns has no resource

### DIFF
--- a/scss/secondary-header.scss
+++ b/scss/secondary-header.scss
@@ -18,8 +18,8 @@
   // although we should make it at a fixed position to stick the secondary header to the top
 
   top: calc(1rem + var(--pf-c-page__header--Height));
-  right: var(--pf-c-page__main-section--PaddingRight);
-  left:  calc(var(--pf-c-page__main-section--PaddingLeft) + var(--pf-c-page__sidebar--Width));
+  right: 0;
+  left:  var(--pf-c-page__sidebar--Width);
   border-bottom: 1px solid var(--pf-global--BorderColor--100);
 
   .pf-c-divider {

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -477,7 +477,10 @@ export const getPulseForNodeWithPodStatus = node => {
         resourceItems,
         obj => _.get(obj, 'namespace', '') === targetNS
       )
-
+      if (resourceItemsForNS.length === 0) {
+        //one namespace has no deployments
+        pulseArr.push(2)
+      }
       const podObjects = _.filter(
         _.flatten(Object.values(podList)),
         obj =>
@@ -1260,7 +1263,7 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
       )
       : resourcesForCluster.length > 0
         ? _.uniq(_.map(resourcesForCluster, 'namespace'))
-        : [namespace]
+        : ['*']
     targetNSList.forEach(targetNS => {
       let res = _.find(
         resourcesForCluster,

--- a/tests/jest/components/Topology/viewer/defaults/details.test.js
+++ b/tests/jest/components/Topology/viewer/defaults/details.test.js
@@ -995,7 +995,7 @@ describe("getNodeDetails helm node", () => {
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "local-cluster" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
 

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -3202,16 +3202,16 @@ describe("setResourceDeployStatus 1 ", () => {
     { type: "label", labelKey: "resource.deploy.statuses" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "braveman" },
-    { labelValue: "default", value: "Not Deployed", status: "pending" },
+    { labelValue: "*", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "possiblereptile" },
-    { labelValue: "default", value: "Not Deployed", status: "pending" },
+    { labelValue: "*", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "sharingpenguin" },
-    { labelValue: "default", value: "Not Deployed", status: "pending" },
+    { labelValue: "*", value: "Not Deployed", status: "pending" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "relievedox" },
-    { labelValue: "default", value: "Not Deployed", status: "pending" },
+    { labelValue: "*", value: "Not Deployed", status: "pending" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus not deployed 1", () => {
@@ -3649,7 +3649,7 @@ describe("setResourceDeployStatus 2 with filter yellow", () => {
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "possiblereptile" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus deployed 2 - should filter resource", () => {
@@ -3694,7 +3694,7 @@ describe("setResourceDeployStatus 2 with filter orange", () => {
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "possiblereptile" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("setResourceDeployStatus deployed 2 - should filter resource", () => {
@@ -3761,16 +3761,16 @@ describe("setResourceDeployStatus 3 ", () => {
     { labelKey: "resource.deploy.statuses", type: "label" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "braveman" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "possiblereptile" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "sharingpenguin" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" },
     { labelValue: "Cluster name", value: "relievedox" },
-    { labelValue: "default", status: "pending", value: "Not Deployed" },
+    { labelValue: "*", status: "pending", value: "Not Deployed" },
     { type: "spacer" }
   ];
   it("shows resources as not deployed", () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11215

Changes:
- updated secondary header width, removed padding
- show * as the namespace when a resource is not deployed on a cluster. This is to cover argo scenarios where the resource has not deployments but there can be more then one namespace targeting that cluster ; we don't know the list of all missing deployments per ns so use a generic *
<img width="633" alt="Screen Shot 2021-04-13 at 5 22 17 PM" src="https://user-images.githubusercontent.com/43010150/114623388-34772280-9c7d-11eb-8c16-d0b15b2d5396.png">

- show warning status if on a cluster one ns has no deployment, but other have ( argo case )
<img width="783" alt="Screen Shot 2021-04-13 at 4 37 05 PM" src="https://user-images.githubusercontent.com/43010150/114622942-a13ded00-9c7c-11eb-9a45-0967a0e7565b.png">
