### PR TITLE
default app topo filter to local-cluster

### DIFF
--- a/src-web/components/ApplicationTopologyModule/ApplicationTopologyModule.js
+++ b/src-web/components/ApplicationTopologyModule/ApplicationTopologyModule.js
@@ -465,7 +465,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const { params: { namespace, name }, location: { search } } = ownProps
   const searchItems = search ? new URLSearchParams(search) : undefined
   let cluster = 'local-cluster'
-  let apiVersion = 'app.k8s.io%2Fv1beta1'
+  let apiVersion = 'app.k8s.io/v1beta1'
   if (searchItems && searchItems.get('apiVersion')) {
     apiVersion = searchItems.get('apiVersion')
   }

--- a/src-web/components/ApplicationTopologyModule/ApplicationTopologyModule.js
+++ b/src-web/components/ApplicationTopologyModule/ApplicationTopologyModule.js
@@ -464,8 +464,14 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch, ownProps) => {
   const { params: { namespace, name }, location: { search } } = ownProps
   const searchItems = search ? new URLSearchParams(search) : undefined
-  const apiVersion = searchItems ? searchItems.get('apiVersion') : undefined
-  const cluster = searchItems ? searchItems.get('cluster') : undefined
+  let cluster = 'local-cluster'
+  let apiVersion = 'app.k8s.io%2Fv1beta1'
+  if (searchItems && searchItems.get('apiVersion')) {
+    apiVersion = searchItems.get('apiVersion')
+  }
+  if (searchItems && searchItems.get('cluster')) {
+    cluster = searchItems.get('cluster')
+  }
   return {
     resetFilters: () => {
       dispatch({


### PR DESCRIPTION
If no cluster or version is set on the single app query, the topology should default to local-cluster and acm app version
At the moment if you don't set a cluster name, which is all the time with the exception of remote argo apps, the topology uses null as the value