### PR TITLE
fix test git commit hash to point to private repo

### DIFF
--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -36,7 +36,7 @@ git:
           token: ""
           branch: master
           path: helloworld
-          commitHash: a95009282563d40521fe738b6e8ff1741bec528f
+          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private cluster hash!
           gitReconcileOption: merge
           repositoryReconcileRate: medium
           deployment:

--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -4,7 +4,7 @@ git:
     - enable: true
       name: ui-git
       type: git
-      successNumber: 0 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
+      successNumber: 3 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
       new: # used when we add new subscriptions after app creation
         - url: https://dummy/insecureSkipVerifyOption
           username: ""

--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -4,7 +4,7 @@ git:
     - enable: true
       name: ui-git
       type: git
-      successNumber: 3 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
+      successNumber: 0 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
       new: # used when we add new subscriptions after app creation
         - url: https://dummy/insecureSkipVerifyOption
           username: ""

--- a/tests/cypress/config/config.e2e.yaml
+++ b/tests/cypress/config/config.e2e.yaml
@@ -36,7 +36,7 @@ git:
           token: ""
           branch: master
           path: helloworld
-          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private cluster hash!
+          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private repo hash!
           gitReconcileOption: merge
           repositoryReconcileRate: medium
           deployment:

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -23,7 +23,7 @@ git:
     - enable: true
       name: ui-git
       type: git
-      successNumber: 3 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
+      successNumber: 0 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
       new: # used when we add new subscriptions after app creation
         - url: https://dummy/insecureSkipVerifyOption
           username: ""

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -23,7 +23,7 @@ git:
     - enable: true
       name: ui-git
       type: git
-      successNumber: 0 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
+      successNumber: 3 #should have at least this many resources with status success in the cards status; note that we can validate this only when at least one subscription is NOT using online: true !
       new: # used when we add new subscriptions after app creation
         - url: https://dummy/insecureSkipVerifyOption
           username: ""

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -55,7 +55,7 @@ git:
           token: ""
           branch: master
           path: helloworld
-          commitHash: a95009282563d40521fe738b6e8ff1741bec528f
+          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private cluster hash!
           gitReconcileOption: merge
           repositoryReconcileRate: medium
           deployment:

--- a/tests/cypress/config/config.func.yaml
+++ b/tests/cypress/config/config.func.yaml
@@ -55,7 +55,7 @@ git:
           token: ""
           branch: master
           path: helloworld
-          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private cluster hash!
+          commitHash: 1adb859f5e998c53435291444c2d963954969b4d #this has to be the private repo hash!
           gitReconcileOption: merge
           repositoryReconcileRate: medium
           deployment:


### PR DESCRIPTION
https://travis-ci.com/github/open-cluster-management/canary/builds/223209059

https://github.com/open-cluster-management/backlog/issues/10745

found the git app deploy error, test calibration issue again, a PR is running now
- e2e test is using a new backend function to enable commit hash
- the e2e test was using a hash from the public git repo - canaries and our PR is switching to test a private repo where this hash is not valid
- our PR didn't catch the issue because the e2e cluster is not patched with the latest backend code; had a lot of issues with 
- updating the e2e clusters, still investigating why; fyi @KevinFCormier 
canary caught it since is using the latest runtime