### PR TITLE
Display target revision as HEAD when it's not set

### DIFF
--- a/src-web/components/common/OverviewCards/index.js
+++ b/src-web/components/common/OverviewCards/index.js
@@ -273,8 +273,10 @@ class OverviewCards extends React.Component {
                             pathname: appOverviewCardsData.argoSource.repoURL,
                             gitPath: appOverviewCardsData.argoSource.path,
                             chart: appOverviewCardsData.argoSource.chart,
-                            targetRevision:
-                              appOverviewCardsData.argoSource.targetRevision
+                            targetRevision: appOverviewCardsData.argoSource
+                              .targetRevision
+                              ? appOverviewCardsData.argoSource.targetRevision
+                              : 'HEAD'
                           }
                         ]}
                         locale={locale}


### PR DESCRIPTION
To be consistent with applications table view
https://github.com/open-cluster-management/backlog/issues/11482


<img width="991" alt="Screen Shot 2021-04-15 at 4 38 53 PM" src="https://user-images.githubusercontent.com/11761226/114935374-1807f100-9e09-11eb-8c01-c15601637a63.png">
