### PR TITLE
Add Argo app status to details

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -387,6 +387,7 @@ resource.application.error = Error
 resource.argo.application.health=Health status
 resource.application.error.msg=This application has no matched subscription. Make sure the subscription match selector spec.selector.matchExpressions exists and matches a Subscription resource created in the {0} namespace.
 resource.argo.application.error.msg=The health status for application {0} is {1}. Use the Launch Argo editor action below to view the application details.
+resource.argo.application.error.msg.appitem=The health status for application {0} is {1}. Use the Launch Argo editor action above to view the application details.
 resource.applications = Applications
 resource.argo.app.cluster=Created on
 resource.argo.app.route.err = No Argo route found for namespace {0} on cluster {1}

--- a/src-web/components/Topology/viewer/ArgoAppDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ArgoAppDetailsContainer.js
@@ -357,6 +357,68 @@ class ArgoAppDetailsContainer extends React.Component {
     )
   };
 
+  mapArgoStatusToStatusIcon = status => {
+    if (status === 'Healthy') {
+      return 'checkmark'
+    }
+    if (status === 'Missing' || status === 'Unknown') {
+      return 'pending'
+    }
+    if (status === 'Degraded') {
+      return 'failure'
+    }
+    return 'warning'
+  };
+
+  renderArgoAppStatusIcon = icon => {
+    const fillMap = new Map([
+      ['checkmark', '#3E8635'],
+      ['failure', '#C9190B'],
+      ['warning', '#F0AB00'],
+      ['pending', '#878D96']
+    ])
+    const iconFill = fillMap.get(icon)
+    return (
+      <svg width="12px" height="12px" fill={iconFill}>
+        <use href={`#diagramIcons_${icon}`} className="label-icon" />
+      </svg>
+    )
+  };
+
+  renderErrorMessage = (name, status, locale) => {
+    let showError = false
+    if (status === 'Unknown' || status === 'Degraded' || status === 'Missing') {
+      showError = true
+    }
+
+    return (
+      showError && (
+        <div className="sectionContent borderLeft">
+          <span className="label sectionLabel">
+            <svg
+              width="10px"
+              height="10px"
+              fill="#C9190B"
+              style={{ marginRight: '8px' }}
+            >
+              <use href="#diagramIcons_failure" className="label-icon" />
+            </svg>
+            <span>
+              {msgs.get('resource.argo.application.health', locale)}:{' '}
+            </span>
+          </span>
+          <span className="value">
+            {msgs.get(
+              'resource.argo.application.error.msg.appitem',
+              [name, status],
+              locale
+            )}:{' '}
+          </span>
+        </div>
+      )
+    )
+  };
+
   render() {
     const {
       selected,
@@ -390,8 +452,10 @@ class ArgoAppDetailsContainer extends React.Component {
         cluster,
         namespace,
         destinationCluster,
-        destinationNamespace
+        destinationNamespace,
+        status
       } = displayArgoAppList[i]
+      const statusIcon = this.mapArgoStatusToStatusIcon(status)
       const parentDivStyle =
         i === startIdx
           ? {
@@ -434,6 +498,8 @@ class ArgoAppDetailsContainer extends React.Component {
               isExpanded={expandSectionToggleMap.has(toggleItemNum)}
               id={name}
             >
+              {this.renderArgoAppStatusIcon(statusIcon)}
+              <span style={{ paddingRight: '10px' }} />
               {name}
             </AccordionToggle>
             <AccordionContent
@@ -474,7 +540,14 @@ class ArgoAppDetailsContainer extends React.Component {
                 </span>
                 <span className={valueClass}>{destinationNamespace}</span>
               </div>
+              <div className={divClass}>
+                <span className={labelClass}>
+                  {msgs.get('resource.status', locale)}:{' '}
+                </span>
+                <span className={valueClass}>{status}</span>
+              </div>
               <div className="spacer" />
+              {this.renderErrorMessage(name, status, locale)}
             </AccordionContent>
           </AccordionItem>
           <span style={outerArgoEditorLinkStyle}>

--- a/tests/jest/components/Topology/viewer/__snapshots__/ArgoAppDetailsContainer.test.js.snap
+++ b/tests/jest/components/Topology/viewer/__snapshots__/ArgoAppDetailsContainer.test.js.snap
@@ -174,6 +174,23 @@ exports[`ArgoAppDetailsContainer with no apps renders as expected 2`] = `
           <span
             className="pf-c-accordion__toggle-text"
           >
+            <svg
+              fill="#F0AB00"
+              height="12px"
+              width="12px"
+            >
+              <use
+                className="label-icon"
+                href="#diagramIcons_warning"
+              />
+            </svg>
+            <span
+              style={
+                Object {
+                  "paddingRight": "10px",
+                }
+              }
+            />
             test1
           </span>
           <span
@@ -333,6 +350,20 @@ exports[`ArgoAppDetailsContainer with no apps renders as expected 2`] = `
             />
           </div>
           <div
+            className="sectionContent borderLeft"
+          >
+            <span
+              className="label sectionLabel"
+            >
+              Status
+              :
+               
+            </span>
+            <span
+              className="value"
+            />
+          </div>
+          <div
             className="spacer"
           />
         </div>
@@ -388,6 +419,23 @@ exports[`ArgoAppDetailsContainer with no apps renders as expected 2`] = `
           <span
             className="pf-c-accordion__toggle-text"
           >
+            <svg
+              fill="#F0AB00"
+              height="12px"
+              width="12px"
+            >
+              <use
+                className="label-icon"
+                href="#diagramIcons_warning"
+              />
+            </svg>
+            <span
+              style={
+                Object {
+                  "paddingRight": "10px",
+                }
+              }
+            />
             test2
           </span>
           <span
@@ -539,6 +587,20 @@ exports[`ArgoAppDetailsContainer with no apps renders as expected 2`] = `
               className="label sectionLabel"
             >
               Destination namespace
+              :
+               
+            </span>
+            <span
+              className="value"
+            />
+          </div>
+          <div
+            className="sectionContent borderLeft"
+          >
+            <span
+              className="label sectionLabel"
+            >
+              Status
               :
                
             </span>

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -343,6 +343,7 @@
   "resource.argo.application.health": "Health status",
   "resource.application.error.msg": "This application has no matched subscription. Make sure the subscription match selector spec.selector.matchExpressions exists and matches a Subscription resource created in the {0} namespace.",
   "resource.argo.application.error.msg": "The health status for application {0} is {1}. Use the Launch Argo editor action below to view the application details.",
+  "resource.argo.application.error.msg.appitem": "The health status for application {0} is {1}. Use the Launch Argo editor action above to view the application details.",
   "resource.applications": "Applications",
   "resource.argo.app.cluster": "Created on",
   "resource.argo.app.route.err": "No Argo route found for namespace {0} on cluster {1}",


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/10943

- Added Argo app status icon
- Alerts user of potential error in Argo app

<img width="1362" alt="image" src="https://user-images.githubusercontent.com/38960034/115097842-8678ac00-9efa-11eb-94ae-1554321060f4.png">

