### PR TITLE
Fix topo crash for nested Argo apps

### DIFF
--- a/src-web/components/Topology/viewer/defaults/status.js
+++ b/src-web/components/Topology/viewer/defaults/status.js
@@ -164,10 +164,11 @@ export const updateNodeIcons = nodes => {
 
     if (
       type === 'application' &&
-      (specs.raw && specs.raw.apiVersion.indexOf('argoproj.io') > -1)
+      (specs.raw && specs.raw.apiVersion.indexOf('argoproj.io') > -1) &&
+      specs.isDesign
     ) {
       layout.argoAppCountIcon = ArgoAppCountIcon
-      layout.argoAppCount = specs.relatedApps.length
+      layout.argoAppCount = specs.relatedApps ? specs.relatedApps.length : 0
     }
 
     if (type === 'cluster') {


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/11740

- Fixed the topo crash when an ACM app contains a nested Argo app
- Also removed the app count for the nested Argo app node

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/38960034/115466960-c8596900-a1fe-11eb-8c1d-1687826778e0.png">
