### PR TITLE
Add steps for users to generate their own certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ build-harness/
 !vbh/build-harness-extensions
 tests/userCreatedByTestSuite
 userCreatedByTestSuite
-sslcert
+sslcert/server.crt
+sslcert/server.key
+sslcert/server.csr
 Dockerfile.tmp

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This UI Platform is developed as an isomorphic react application.  The following
 git clone https://github.com/open-cluster-management/application-ui.git
 cd application-ui
 npm install
-npm run build:production
+npm run build
 </pre>
 
 
@@ -80,6 +80,7 @@ npm run build:production
 By default the server runs in development mode using **insecure** HTTP connections. To use HTTPS, you must either:
 - set the environment variables `serverKey` and `serverCert` with the full path of the key and certificate files
 - provide a key and certificate in the `./sslcert/server.key` and `./sslcert/server.crt` files
+- follow the README steps in ./sslcert to generate new certificate files
 
 To run in production mode, set `NODE_ENV` to `production` and provide a key and certificate in `./certs/applicationui.key` and `./certs/applicationui.crt`.
 
@@ -168,6 +169,7 @@ To run your local `application-ui` code against an existing OCM installation:
 <pre>
 git clone https://github.com/open-cluster-management/application-ui.git
 cd application-ui
+export export USE_VENDORIZED_BUILD_HARNESS=false
 export COMPONENT_DOCKER_REPO=&lt;docker_repo&gt;
 export COMPONENT_NAME=application-ui
 export IMAGE_TAG=&lt;image_tag&gt;

--- a/build/run-e2e-tests-clusterpool.sh
+++ b/build/run-e2e-tests-clusterpool.sh
@@ -82,7 +82,7 @@ echo "Running pull-test-image..."
 make pull-test-image
 
 # Set up HTTPS
-mkdir sslcert
+mkdir -p sslcert
 echo "$SERVER_KEY" > sslcert/server.key
 echo "$SERVER_CRT" > sslcert/server.crt
 export CYPRESS_BASE_URL=https://localhost:3001

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -38,7 +38,7 @@ echo "Running pull-test-image..."
 make pull-test-image
 
 # Set up HTTPS
-mkdir sslcert
+mkdir -p sslcert
 echo "$SERVER_KEY" > sslcert/server.key
 echo "$SERVER_CRT" > sslcert/server.crt
 export CYPRESS_BASE_URL=https://localhost:3001

--- a/sslcert/README.md
+++ b/sslcert/README.md
@@ -1,0 +1,6 @@
+# These certificates are only for development
+
+To generate a certificate for development run the following in this directory (./sslcert)
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -config req.conf -extensions 'v3_req'
+```

--- a/sslcert/req.conf
+++ b/sslcert/req.conf
@@ -1,0 +1,12 @@
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = US
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Added steps in the README so users can generate their own certs since it doesn't work when we try to run in HTTP dev mode