### PR TITLE
fix deploy resource status when not deploying on local cluster

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -34,7 +34,9 @@ import {
   getPulseStatusForArgoApp,
   updateAppClustersMatchingSearch,
   showMissingClusterDetails,
-  getTargetNsForNode
+  getTargetNsForNode,
+  nodesWithNoNS,
+  getResourcesClustersForApp
 } from './diagram-helpers-utils'
 import { getEditLink } from '../../../../lib/client/resource-helper'
 import { openArgoCDEditor } from '../../../actions/topology'
@@ -328,7 +330,9 @@ const getPulseStatusForGenericNode = node => {
   clusterNames.forEach(clusterName => {
     clusterName = R.trim(clusterName)
     //get target cluster namespaces
-    const resourceNSString = nodeType === 'namespace' ? 'name' : 'namespace'
+    const resourceNSString = _.includes(nodesWithNoNS, nodeType)
+      ? 'name'
+      : 'namespace'
     const resourcesForCluster = _.filter(
       _.flatten(Object.values(resourceMap)),
       obj => _.get(obj, 'cluster', '') === clusterName
@@ -1001,12 +1005,13 @@ export const setupResourceModel = (
     return resourceMap
   }
   // store cluster objects and cluster names as returned by search; these are clusters related to the app
-  const clustersList = R.find(R.propEq('kind', 'cluster'))(list) || {}
-  const clustersObjects = R.pathOr([], ['items'])(clustersList)
+  const clustersObjects = getResourcesClustersForApp(
+    R.find(R.propEq('kind', 'cluster'))(list) || {},
+    topology.nodes
+  )
   const clusterNamesList = R.sortBy(R.identity)(
     R.pluck('name')(clustersObjects)
   )
-
   if (topology.nodes) {
     const appNode =
       _.find(
@@ -1269,7 +1274,9 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
       _.flatten(Object.values(resourceMap)),
       obj => _.get(obj, 'cluster', '') === clusterName
     )
-    const resourceNSString = nodeType === 'namespace' ? 'name' : 'namespace'
+    const resourceNSString = _.includes(nodesWithNoNS, nodeType)
+      ? 'name'
+      : 'namespace'
     //get cluster target namespaces
     const targetNSList = getTargetNsForNode(
       node,


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

We now show resource status for clusters targeted by the app but offline; or resources not deployed at all
We show a not deployed status for resources if a cluster is returned by the search query but there is no resource for this type of node on that cluster
Local cluster is a particular case : it is always returned by search since app links to the cluster is deployed on. So we always expect all nodes to be deployed on local cluster , even if the placement doesn't ask for it. This is a bug and is fixed here. 
I am removing the local cluster from the list of search clusters if I cannot find any placement rule decision containing the local cluster

<img width="1102" alt="Screen Shot 2021-04-25 at 1 00 42 AM" src="https://user-images.githubusercontent.com/43010150/115981444-d7734a80-a561-11eb-94aa-ba682a2bfc5e.png">
<img width="1028" alt="Screen Shot 2021-04-25 at 1 01 19 AM" src="https://user-images.githubusercontent.com/43010150/115981445-d93d0e00-a561-11eb-9c09-1f168ec18470.png">
