### PR TITLE
Fix cluster not selectable from dropdown

### DIFF
--- a/src-web/components/Topology/viewer/ClusterDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ClusterDetailsContainer.js
@@ -110,9 +110,10 @@ class ClusterDetailsContainer extends React.Component {
     const { clusterID } = this.state
     let selectedCluster, newClusterList
     if (selection) {
-      selectedCluster = clusterList.find(
-        cls => cls.metadata.name === selection
-      )
+      selectedCluster =
+        clusterID === 'member--clusters--'
+          ? clusterList.find(cls => cls.name === selection)
+          : clusterList.find(cls => cls.metadata.name === selection)
       newClusterList = [selectedCluster]
     } else {
       newClusterList = clusterList


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/11973

Cluster selection is working now:
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/38960034/116300640-1e815b80-a76d-11eb-8da7-0c27348f96f4.png">
