### PR TITLE
Fix UI crash when user clicks on cluster node before search finishes loading

### DIFF
--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -347,7 +347,14 @@ const setArgoAppDetails = (
   //desired deployment state
   lodash.set(firstNode, 'specs.clusterNames', appData.clusterInfo)
   lodash.set(topoClusterNode, 'specs.appClusters', appData.clusterInfo)
-  lodash.set(topoClusterNode, 'specs.clusters', appData.clusterInfo)
+  const initialClusterData = []
+  //make sure clusters array always contain only objects
+  appData.clusterInfo.forEach(cls => {
+    initialClusterData.push({
+      name: cls
+    })
+  })
+  lodash.set(topoClusterNode, 'specs.clusters', initialClusterData)
   lodash.set(topoClusterNode, 'specs.targetNamespaces', targetNSForClusters)
 
   fetchApplicationRelatedObjects(

--- a/src-web/components/Topology/viewer/ArgoAppDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ArgoAppDetailsContainer.js
@@ -497,7 +497,11 @@ class ArgoAppDetailsContainer extends React.Component {
       }
       // render list of argo app
       appItems.push(
-        <div className="appDetailItem" style={parentDivStyle} key={name}>
+        <div
+          className="appDetailItem"
+          style={parentDivStyle}
+          key={`${name}${i}`}
+        >
           <AccordionItem>
             <AccordionToggle
               onClick={() => this.handleExpandSectionToggle(toggleItemNum)}

--- a/src-web/components/Topology/viewer/ClusterDetailsContainer.js
+++ b/src-web/components/Topology/viewer/ClusterDetailsContainer.js
@@ -110,10 +110,10 @@ class ClusterDetailsContainer extends React.Component {
     const { clusterID } = this.state
     let selectedCluster, newClusterList
     if (selection) {
-      selectedCluster =
-        clusterID === 'member--clusters--'
-          ? clusterList.find(cls => cls.name === selection)
-          : clusterList.find(cls => cls.metadata.name === selection)
+      selectedCluster = clusterList.find(
+        cls =>
+          cls.name ? cls.name === selection : cls.metadata.name === selection
+      )
       newClusterList = [selectedCluster]
     } else {
       newClusterList = clusterList


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Fix an UI crashes when the user clicks on the cluster node before search finishes loading:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/38960034/116318821-5b584d00-a783-11eb-918d-cc39cac1c02f.png">

Now displays the details before search loads:
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/38960034/116318858-70cd7700-a783-11eb-9914-ce15ceca0d8d.png">

When search finishes, the details will update to the loaded data:
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/38960034/116318903-8b9feb80-a783-11eb-8ad9-6d30a7143615.png">

Also fixes an issue with duplicate key in the Argo related apps:
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/38960034/116318959-abcfaa80-a783-11eb-8a8c-fb0dcd3a68f7.png">
