### PR TITLE
use search clusters to show app cards cluster status

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -585,13 +585,16 @@ export const showMissingClusterDetails = (clusterName, node, details) => {
         _.get(node, 'specs.searchClusters', []),
         cls => _.get(cls, 'name') === clusterName
       )
+      const isOffline =
+        searchCluster &&
+        _.get(searchCluster, '_clusterNamespace', '').length > 1
       nsForCluster.forEach(nsName => {
         details.push({
           labelValue: nsName,
-          value: searchCluster
+          value: isOffline
             ? msgs.get('resource.cluster.offline')
             : msgs.get('spec.deploy.not.deployed'),
-          status: searchCluster ? warningStatus : pendingStatus
+          status: isOffline ? warningStatus : pendingStatus
         })
       })
     }
@@ -654,4 +657,14 @@ export const getResourcesClustersForApp = (searchClusters, nodes) => {
     }
   }
   return clustersList
+}
+
+export const allClustersAreOnline = (clusterNames, onlineClusters) => {
+  if (onlineClusters && clusterNames) {
+    return (
+      _.intersection(onlineClusters, clusterNames).length ===
+      clusterNames.length
+    )
+  }
+  return false
 }

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -35,7 +35,8 @@ import {
   showMissingClusterDetails,
   getTargetNsForNode,
   nodesWithNoNS,
-  getResourcesClustersForApp
+  getResourcesClustersForApp,
+  allClustersAreOnline
 } from './diagram-helpers-utils'
 import { getEditLink } from '../../../../lib/client/resource-helper'
 import { openArgoCDEditor, openRouteURL } from '../../../actions/topology'
@@ -358,8 +359,7 @@ const getPulseStatusForGenericNode = node => {
     pulse = 'orange' //resource not available
     return pulse
   }
-
-  if (onlineClusters.length < clusterNames.length) {
+  if (!allClustersAreOnline(clusterNames, onlineClusters)) {
     pulse = 'yellow'
     return pulse
   }
@@ -582,7 +582,7 @@ export const getPulseForNodeWithPodStatus = node => {
   pulse = pulseValueArr[minPulse] || pulseValueArr[2] //show orange is no pods
   _.set(node, 'podStatusMap', podStatusMap)
 
-  if (onlineClusters.length < clusterNames.length) {
+  if (!allClustersAreOnline(clusterNames, onlineClusters)) {
     pulse = 'yellow'
   }
 
@@ -1074,17 +1074,6 @@ export const setupResourceModel = (
         // only do this for Argo clusters
         //cluster node, set search found clusters objects here
         updateAppClustersMatchingSearch(node, clustersObjects)
-        // set clusters status on the app node, this is an argo app
-        // we have all clusters information here
-        const argoAppNode = topology.nodes[0]
-        // search returns clusters information, use it here
-        const isLocal = clusterNamesList.indexOf(LOCAL_HUB_NAME) !== -1
-        _.set(argoAppNode, 'specs.allClusters', {
-          isLocal,
-          remoteCount: isLocal
-            ? clusterNamesList.length - 1
-            : clusterNamesList.length
-        })
       }
       const nodeClusters = nodeId.startsWith('member--subscription')
         ? clusterNamesList
@@ -1107,6 +1096,22 @@ export const setupResourceModel = (
           )
           : clustersObjects
       )
+    })
+    // set clusters status on the app node
+    // we have all clusters information here
+    const appNodeSearchClusters = _.get(appNode, 'specs.searchClusters', [])
+    // search returns clusters information, use it here
+    const isLocal = _.find(
+      appNodeSearchClusters,
+      cls => _.get(cls, 'name', '') === LOCAL_HUB_NAME
+    )
+      ? true
+      : false
+    _.set(appNode, 'specs.allClusters', {
+      isLocal,
+      remoteCount: isLocal
+        ? appNodeSearchClusters.length - 1
+        : appNodeSearchClusters.length
     })
   }
   const podIndex = _.findIndex(list, ['kind', 'pod'])

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -1090,11 +1090,11 @@ export const setupResourceModel = (
       _.set(
         node,
         'specs.searchClusters',
-        hasMultipleSubs
+        hasMultipleSubs && !nodeId.startsWith('application--')
           ? _.filter(clustersObjects, cls =>
             _.includes(nodeClusters, _.get(cls, 'name', ''))
           )
-          : clustersObjects
+          : clustersObjects // get all search clusters when one cluster node or this is the main app node
       )
     })
     // set clusters status on the app node

--- a/tests/jest/components/ApplicationTopologyModule/definitions/hcm-application-diagram.test.js
+++ b/tests/jest/components/ApplicationTopologyModule/definitions/hcm-application-diagram.test.js
@@ -234,7 +234,7 @@ describe("hcm-application-diagram-tests", () => {
       },
       {
         id:
-          "--clusters--possiblereptile,braveman,sharingpenguin,relievedox--app",
+          "application--clusters--possiblereptile,braveman,sharingpenguin,relievedox--app",
         type: "application",
         name: "aa",
         namespace: "ns",
@@ -591,10 +591,6 @@ describe("hcm-application-diagram-tests", () => {
               status: "ok"
             }
           ],
-          allClusters: {
-            isLocal: false,
-            remoteCount: 1
-          },
           clustersNames: ["sharingpenguin"],
           searchClusters: [
             {
@@ -655,10 +651,11 @@ describe("hcm-application-diagram-tests", () => {
           }
         },
         id:
-          "--clusters--possiblereptile,braveman,sharingpenguin,relievedox--app",
+          "application--clusters--possiblereptile,braveman,sharingpenguin,relievedox--app",
         name: "aa",
         namespace: "ns",
         specs: {
+          allClusters: { isLocal: false, remoteCount: 1 },
           clustersNames: [
             "braveman",
             "possiblereptile",
@@ -684,10 +681,6 @@ describe("hcm-application-diagram-tests", () => {
                 status: "ok"
               }
             ],
-            allClusters: {
-              isLocal: false,
-              remoteCount: 1
-            },
             clustersNames: ["sharingpenguin"],
             searchClusters: [
               {

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -18,8 +18,29 @@ import {
   namespaceMatchTargetServer,
   updateAppClustersMatchingSearch,
   getTargetNsForNode,
-  getResourcesClustersForApp
+  getResourcesClustersForApp,
+  allClustersAreOnline
 } from "../../../../../../src-web/components/Topology/utils/diagram-helpers-utils";
+
+describe("allClustersAreOnline", () => {
+  const onlineClusters = ["cls1", "cls2"];
+  it("returns true ", () => {
+    expect(allClustersAreOnline(["cls1", "cls2"], onlineClusters)).toEqual(
+      true
+    );
+  });
+
+  it("returns false ", () => {
+    expect(
+      allClustersAreOnline(["cls1", "cls2", "cls3"], onlineClusters)
+    ).toEqual(false);
+  });
+  it("returns false ", () => {
+    expect(allClustersAreOnline(["cls1", "cls2", "cls3"], undefined)).toEqual(
+      false
+    );
+  });
+});
 
 describe("getResourcesClustersForApp", () => {
   const searchClusters = {


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

Use search returned clusters to define the list of clusters the app has deployed to
The placement rule status is not sufficient
- the app can deploy on clusters using the placement rule = deploy on all active
- some clusters go offline
- pr ignores the offline clusters; search returns the resources deployed on the clusters

Before

<img width="935" alt="Screen Shot 2021-04-29 at 9 16 23 AM" src="https://user-images.githubusercontent.com/43010150/116556613-a0879680-a8cb-11eb-8322-4d4e54c2e05d.png">

because the PR points to 3 clusters ( the rest are offline and the PR is set to deploy to all active )
<img width="1140" alt="Screen Shot 2021-04-29 at 9 17 18 AM" src="https://user-images.githubusercontent.com/43010150/116556757-d0369e80-a8cb-11eb-963a-0722e7a57c95.png">



With the fix, use all search cluster

<img width="954" alt="Screen Shot 2021-04-29 at 8 28 25 AM" src="https://user-images.githubusercontent.com/43010150/116556438-6fa76180-a8cb-11eb-932a-250e56a49842.png">
<img width="1038" alt="Screen Shot 2021-04-29 at 8 28 50 AM" src="https://user-images.githubusercontent.com/43010150/116556441-70d88e80-a8cb-11eb-8600-4e7738a43b64.png">
