### PR TITLE
hook nodes should ignore remote clusters

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -1261,11 +1261,14 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
   const namespace =
     _.get(node, metadataNamespace) || _.get(node, 'namespace', '')
 
-  const clusterNames = R.split(',', getClusterName(nodeId, node, true))
+  const isHookNode = _.get(node, 'specs.raw.hookType')
+  const clusterNames = isHookNode
+    ? [LOCAL_HUB_NAME]
+    : R.split(',', getClusterName(nodeId, node, true))
   const resourceMap = _.get(node, `specs.${node.type}Model`, {})
   const onlineClusters = getOnlineClusters(node)
 
-  if (nodeType === 'ansiblejob' && _.get(node, 'specs.raw.hookType')) {
+  if (nodeType === 'ansiblejob' && isHookNode) {
     // process here only ansible hooks
     showAnsibleJobDetails(node, details)
 
@@ -1340,10 +1343,7 @@ export const setResourceDeployStatus = (node, details, activeFilters) => {
         resourcesForCluster,
         obj => _.get(obj, resourceNSString, '') === targetNS
       )
-      if (
-        _.get(node, 'type', '') !== 'ansiblejob' ||
-        !_.get(node, 'specs.raw.hookType')
-      ) {
+      if (_.get(node, 'type', '') !== 'ansiblejob' || !isHookNode) {
         // process here only regular ansible tasks
         const deployedKey = res
           ? node.type === 'namespace' ? deployedNSStr : deployedStr

--- a/tests/jest/components/TestingData.js
+++ b/tests/jest/components/TestingData.js
@@ -8,6 +8,152 @@
  ****************************************************************************** */
 // Copyright (c) 2020 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+export const ansibleSuccess = {
+  type: "ansiblejob",
+  name: "bigjoblaunch",
+  namespace: "default",
+  id:
+    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
+  specs: {
+    clustersNames: ["local-cluster"],
+    searchClusters: ["local-cluster"],
+    raw: {
+      metadata: {
+        name: "bigjoblaunch",
+        namespace: "default"
+      },
+      spec: {
+        ansibleJobResult: {
+          url: "http://ansible_url/job",
+          status: "successful"
+        },
+        conditions: [
+          {
+            ansibleResult: {},
+            message: "Success",
+            reason: "Successful"
+          }
+        ]
+      }
+    },
+    ansiblejobModel: {
+      "bigjoblaunch-local-cluster": [
+        {
+          label: "tower_job_id=999999999",
+          namespace: "default",
+          cluster: "local-cluster"
+        }
+      ]
+    }
+  }
+};
+export const ansibleError = {
+  type: "ansiblejob",
+  name: "bigjoblaunch",
+  namespace: "default",
+  id:
+    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
+  specs: {
+    clustersNames: ["local-cluster"],
+    searchClusters: ["local-cluster"],
+    raw: {
+      hookType: "pre-hook",
+      metadata: {
+        name: "bigjoblaunch",
+        namespace: "default"
+      }
+    },
+    ansiblejobModel: {
+      "bigjoblaunch-local-cluster": {
+        label: "tower_job_id=999999999"
+      }
+    }
+  }
+};
+export const ansibleError2 = {
+  type: "ansiblejob",
+  name: "bigjoblaunch",
+  namespace: "default",
+  id:
+    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
+  specs: {
+    clustersNames: ["local-cluster"],
+    searchClusters: ["local-cluster"],
+    raw: {
+      hookType: "pre-hook",
+      metadata: {
+        name: "bigjoblaunch",
+        namespace: "default"
+      },
+      spec: {
+        conditions: [
+          {
+            ansibleResult: {
+              failures: 0
+            },
+            message: "Awaiting next reconciliation",
+            reason: "Failed"
+          }
+        ],
+        k8sJob: {
+          message: "some message"
+        }
+      }
+    },
+    ansiblejobModel: {
+      "bigjoblaunch-local-cluster": [
+        {
+          label: "tower_job_id=999999999",
+          cluster: "local-cluster",
+          namespace: "default"
+        }
+      ]
+    }
+  }
+};
+
+export const ansibleErrorAllClusters = {
+  type: "ansiblejob",
+  name: "bigjoblaunch",
+  namespace: "default",
+  id:
+    "member--member--deployable--member--clusters--fxiang-eks,local-cluster,ui-remote--vb-ansible-2--prehook-test-1-c0b22a--ansiblejob--prehook-test-1-c0b22a",
+  specs: {
+    clustersNames: ["local-cluster", "ui-remote", "fxiang-eks"],
+    searchClusters: ["local-cluster"],
+    raw: {
+      hookType: "pre-hook",
+      metadata: {
+        name: "bigjoblaunch",
+        namespace: "default"
+      },
+      spec: {
+        conditions: [
+          {
+            ansibleResult: {
+              failures: 0
+            },
+            message: "Awaiting next reconciliation",
+            reason: "Failed"
+          }
+        ],
+        k8sJob: {
+          message: "some message"
+        }
+      }
+    },
+    ansiblejobModel: {
+      "bigjoblaunch-local-cluster": [
+        {
+          label: "tower_job_id=999999999",
+          cluster: "local-cluster",
+          namespace: "default"
+        }
+      ]
+    }
+  }
+};
+
 export const serverProps = {
   context: {
     locale: "en-US"

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -32,113 +32,15 @@ import {
   checkAndObjects
 } from "../../../../../../src-web/components/Topology/utils/diagram-helpers";
 
-import { topology } from "./../../../TestingData";
+import {
+  topology,
+  ansibleSuccess,
+  ansibleError,
+  ansibleError2,
+  ansibleErrorAllClusters
+} from "./../../../TestingData";
 
 window.open = () => {}; // provide an empty implementation for window.open
-
-const ansibleSuccess = {
-  type: "ansiblejob",
-  name: "bigjoblaunch",
-  namespace: "default",
-  id:
-    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
-  specs: {
-    clustersNames: ["local-cluster"],
-    searchClusters: ["local-cluster"],
-    raw: {
-      metadata: {
-        name: "bigjoblaunch",
-        namespace: "default"
-      },
-      spec: {
-        ansibleJobResult: {
-          url: "http://ansible_url/job",
-          status: "successful"
-        },
-        conditions: [
-          {
-            ansibleResult: {},
-            message: "Success",
-            reason: "Successful"
-          }
-        ]
-      }
-    },
-    ansiblejobModel: {
-      "bigjoblaunch-local-cluster": [
-        {
-          label: "tower_job_id=999999999",
-          namespace: "default",
-          cluster: "local-cluster"
-        }
-      ]
-    }
-  }
-};
-const ansibleError = {
-  type: "ansiblejob",
-  name: "bigjoblaunch",
-  namespace: "default",
-  id:
-    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
-  specs: {
-    clustersNames: ["local-cluster"],
-    searchClusters: ["local-cluster"],
-    raw: {
-      hookType: "pre-hook",
-      metadata: {
-        name: "bigjoblaunch",
-        namespace: "default"
-      }
-    },
-    ansiblejobModel: {
-      "bigjoblaunch-local-cluster": {
-        label: "tower_job_id=999999999"
-      }
-    }
-  }
-};
-const ansibleError2 = {
-  type: "ansiblejob",
-  name: "bigjoblaunch",
-  namespace: "default",
-  id:
-    "member--deployable--member--subscription--default--ansible-tower-job-app-subscription--ansiblejob--bigjoblaunch",
-  specs: {
-    clustersNames: ["local-cluster"],
-    searchClusters: ["local-cluster"],
-    raw: {
-      hookType: "pre-hook",
-      metadata: {
-        name: "bigjoblaunch",
-        namespace: "default"
-      },
-      spec: {
-        conditions: [
-          {
-            ansibleResult: {
-              failures: 0
-            },
-            message: "Awaiting next reconciliation",
-            reason: "Failed"
-          }
-        ],
-        k8sJob: {
-          message: "some message"
-        }
-      }
-    },
-    ansiblejobModel: {
-      "bigjoblaunch-local-cluster": [
-        {
-          label: "tower_job_id=999999999",
-          cluster: "local-cluster",
-          namespace: "default"
-        }
-      ]
-    }
-  }
-};
 
 const node = {
   specs: {
@@ -3727,8 +3629,14 @@ describe("setResourceDeployStatus ansiblejob no status", () => {
   it("setResourceDeployStatus ansiblejob no status 1", () => {
     expect(setResourceDeployStatus(ansibleError, [], {})).toEqual(result1);
   });
-  it("getResourceDeployStatus ansiblejob with error status", () => {
+  it("setResourceDeployStatus ansiblejob with error status", () => {
     expect(setResourceDeployStatus(ansibleError2, [], {})).toEqual(result2);
+  });
+
+  it("getResourceDeployStatus ansiblejob with subscription deployed on all active clusters", () => {
+    expect(setResourceDeployStatus(ansibleErrorAllClusters, [], {})).toEqual(
+      result2
+    );
   });
 });
 


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

For ansible hooks we should not show remote clusters as not deployed since hooks are only deployed on hub
Before fix
<img width="616" alt="Screen Shot 2021-05-04 at 9 53 39 AM" src="https://user-images.githubusercontent.com/43010150/117022440-3fdecc00-acc6-11eb-9082-61d9308eda12.png">


With the fix
<img width="752" alt="Screen Shot 2021-05-04 at 10 12 31 AM" src="https://user-images.githubusercontent.com/43010150/117022461-453c1680-acc6-11eb-9d21-fc8f8154b6a2.png">
