### PR TITLE
show argo application set on props dialog, topo

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -355,6 +355,8 @@ props.show.search.view=Launch resource in Search
 props.show.yaml.rules.ns=View all placement rules in {0} namespace
 props.show.yaml.subscr.ns=View all subscriptions in {0} namespace
 props.show.yaml=View Resource YAML
+props.show.yaml.argoset=Application Set
+props.show.yaml.argoset.yaml=View Application Set YAML
 props.view.yaml=View Topology YAML
 
 raw.spec.accessmode=Access Mode

--- a/src-web/components/Topology/utils/diagram-helpers-argo.js
+++ b/src-web/components/Topology/utils/diagram-helpers-argo.js
@@ -1,0 +1,55 @@
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import _ from 'lodash'
+
+import msgs from '../../../../nls/platform.properties'
+import { LOCAL_HUB_NAME } from '../../../../lib/shared/constants'
+
+import { createEditLink } from './diagram-helpers'
+
+export const showArgoApplicationSetLink = (node, details) => {
+  //get application set info
+  const appSet =
+    _.get(node, 'type', '' === 'application') &&
+    _.get(node, 'specs.raw.metadata.ownerReferences', [])
+  if (appSet.length > 0) {
+    details.push({
+      type: 'spacer'
+    })
+
+    // show link to app set
+    details.push({
+      labelValue: msgs.get('props.show.yaml.argoset'),
+      value: _.get(appSet[0], 'name', 'unknown')
+    })
+    const res = {
+      cluster: _.get(node, 'cluster', LOCAL_HUB_NAME),
+      namespace: _.get(node, 'namespace', 'unknown'),
+      name: _.get(appSet[0], 'name', 'unknown'),
+      apiversion: 'v1alpha1',
+      kind: _.get(appSet[0], 'kind', 'unknown'),
+      specs: {
+        raw: {
+          apiVersion: _.get(appSet[0], 'apiVersion', 'argoproj.io/v1alpha1')
+        }
+      }
+    }
+    details.push({
+      type: 'link',
+      value: {
+        label: msgs.get('props.show.yaml.argoset.yaml'),
+        data: {
+          action: 'show_resource_yaml',
+          cluster: res.cluster,
+          editLink: createEditLink(res)
+        }
+      },
+      indent: true
+    })
+    details.push({
+      type: 'spacer'
+    })
+  }
+  return details
+}

--- a/src-web/components/Topology/viewer/defaults/details.js
+++ b/src-web/components/Topology/viewer/defaults/details.js
@@ -26,6 +26,7 @@ import {
   addIngressNodeInfo,
   setClusterStatus
 } from '../../utils/diagram-helpers'
+import { showArgoApplicationSetLink } from '../../utils/diagram-helpers-argo'
 import msgs from '../../../../../nls/platform.properties'
 import { kubeNaming } from './titles'
 
@@ -37,8 +38,12 @@ export const getNodeDetails = (node, updatedNode, activeFilters) => {
     const { type, specs } = node
     const { labels = [] } = node
 
+    // for argo apps with application sets
+    showArgoApplicationSetLink(node, details)
+
     //if resource has a row number add deployable yaml
     createDeployableYamlLink(node, details)
+
     details.push({
       type: 'spacer'
     })

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-argo.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-argo.test.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+"use strict";
+
+import { showArgoApplicationSetLink } from "../../../../../../src-web/components/Topology/utils/diagram-helpers-argo";
+
+describe("showArgoApplicationSetLink", () => {
+  const argoAppsWithAppSet = {
+    id: "application--nginx-in-cluster",
+    type: "application",
+    name: "nginx-in-cluster",
+    namespace: "openshift-gitops",
+    specs: {
+      raw: {
+        apiVersion: "argoproj.io/v1alpha1",
+        kind: "Application",
+        metadata: {
+          ownerReferences: [
+            {
+              kind: "ApplicationSet",
+              name: "nginx-sample"
+            }
+          ]
+        }
+      }
+    }
+  };
+  const argoAppsNoAppSet = {
+    id: "application--nginx-in-cluster",
+    type: "application",
+    name: "nginx-in-cluster",
+    namespace: "openshift-gitops",
+    specs: {
+      raw: {
+        apiVersion: "argoproj.io/v1alpha1",
+        kind: "Application",
+        metadata: {
+          ownerReferences: []
+        }
+      }
+    }
+  };
+
+  const argoAppsNoAppSet2 = {
+    id: "application--nginx-in-cluster",
+    type: "application",
+    name: "nginx-in-cluster",
+    namespace: "openshift-gitops",
+    specs: {
+      raw: {
+        apiVersion: "argoproj.io/v1alpha1",
+        kind: "Application",
+        metadata: {}
+      }
+    }
+  };
+
+  const result = [
+    {
+      type: "spacer"
+    },
+    {
+      labelValue: "Application Set",
+      value: "nginx-sample"
+    },
+    {
+      type: "link",
+      value: {
+        label: "View Application Set YAML",
+        data: {
+          action: "show_resource_yaml",
+          cluster: "local-cluster",
+          editLink:
+            "/resources?apiversion=argoproj.io%2Fv1alpha1&cluster=local-cluster&kind=applicationset&name=nginx-sample&namespace=openshift-gitops"
+        }
+      },
+      indent: true
+    },
+    {
+      type: "spacer"
+    }
+  ];
+  it("returns application set ", () => {
+    expect(showArgoApplicationSetLink(argoAppsWithAppSet, [])).toEqual(result);
+  });
+
+  it("returns no application set ", () => {
+    expect(showArgoApplicationSetLink(argoAppsNoAppSet, [])).toEqual([]);
+  });
+
+  it("returns no application set, no owner ref set", () => {
+    expect(showArgoApplicationSetLink(argoAppsNoAppSet2, [])).toEqual([]);
+  });
+});

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -314,6 +314,8 @@
   "props.show.yaml.rules.ns": "View all placement rules in {0} namespace",
   "props.show.yaml.subscr.ns": "View all subscriptions in {0} namespace",
   "props.show.yaml": "View Resource YAML",
+  "props.show.yaml.argoset": "Application Set",
+  "props.show.yaml.argoset.yaml": "View Application Set YAML",
   "props.view.yaml": "View Topology YAML",
   "raw.spec.accessmode": "Access Mode",
   "raw.spec.channel": "Channel",


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>
https://github.com/open-cluster-management/backlog/issues/11584

If selected argo app has an application set owner, show that in the properties dialog

<img width="771" alt="Screen Shot 2021-05-04 at 11 27 42 AM" src="https://user-images.githubusercontent.com/43010150/117029516-bc74a900-accc-11eb-929a-834b5139b73d.png">
