### PR TITLE
fix resource map when deployables have the same prefix and type

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -260,17 +260,19 @@ export const getExistingResourceMapKey = (resourceMap, name, relatedKind) => {
   // bofore loop, find all items with the same type as relatedKind
   const isSameType = item => item.indexOf(`${relatedKind.kind}-`) === 0
   const keys = R.filter(isSameType, Object.keys(resourceMap))
+  const relatedKindCls = _.get(relatedKind, 'cluster', '')
   let i
   for (i = 0; i < keys.length; i++) {
     const keyObject = resourceMap[keys[i]]
+    const keyObjType = _.get(keyObject, 'type', '')
+    const keyObjName = _.get(keyObject, 'name', '')
     if (
-      (keys[i].indexOf(name) > -1 &&
-        keys[i].indexOf(relatedKind.cluster) > -1) || //node id doesn't contain cluster name, match cluster using the object type
+      (keys[i].indexOf(name) > -1 && keys[i].indexOf(relatedKindCls) > -1) || //node id doesn't contain cluster name, match cluster using the object type
       (_.includes(
         _.get(keyObject, 'specs.clustersNames', []),
-        relatedKind.cluster
+        relatedKindCls
       ) &&
-        name.indexOf(`${keyObject.type}-${keyObject.name}`) === 0)
+        name === `${keyObjType}-${keyObjName}-${relatedKindCls}`)
     ) {
       return keys[i]
     }

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -954,6 +954,18 @@ describe("getExistingResourceMapKey", () => {
     "replicaset-nginx-placement-cluster1, cluster2": "test"
   };
 
+  const resourceMapSamePrefix = {
+    "configmap-cfg-from-ch-qa-cluster1, cluster2": "test",
+    "configmap-cfg-from-ch-qa-2-cluster1, cluster2": "test1",
+    "configmap-cfg-from-ch-qa-3-cluster1, cluster2": relatedKindSamePrefix
+  };
+
+  const relatedKindSamePrefix = {
+    cluster: "cluster1",
+    kind: "configmap",
+    name: "configmap-cfg-from-ch-qa-3"
+  };
+
   const relatedKind = {
     cluster: "cluster1",
     kind: "replicaset"
@@ -962,6 +974,16 @@ describe("getExistingResourceMapKey", () => {
   const relatedKindBadCluster = {
     cluster: "cluster3"
   };
+
+  it("should get key from resourceMap and find the last name", () => {
+    expect(
+      getExistingResourceMapKey(
+        resourceMapSamePrefix,
+        "configmap-cfg-from-ch-qa-3-",
+        relatedKindSamePrefix
+      )
+    ).toEqual("configmap-cfg-from-ch-qa-3-cluster1, cluster2");
+  });
 
   it("should get key from resourceMap", () => {
     expect(


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

When deployable have the same type and prefix, the deployed resources could get linked to the wrong parent
For example:
- have 3 config maps with names : cfg-from-ch-qa, cfg-from-ch-qa-2, cfg-from-ch-qa-3
- deployed resources for cfg-from-ch-qa-3 get linked to cfg-from-ch-qa because this is the first key found that is contained by the deployed resource key name ( we can't do an exact match bc of cluster names and hash added/removed to the 
deployed key name )
The resource keyname is in this format : configmap-cfg-from-ch-qa-3-ui-remote ( type-name-cluster )

The fix checks if the name of the key = deployableType-deployableName-cluster

Without the fix
<img width="1144" alt="Screen Shot 2021-05-05 at 5 29 46 PM" src="https://user-images.githubusercontent.com/43010150/117212137-f5457880-adc7-11eb-8f3a-6454aab63ba2.png">

With the fix

<img width="726" alt="Screen Shot 2021-05-05 at 5 18 02 PM" src="https://user-images.githubusercontent.com/43010150/117212161-fc6c8680-adc7-11eb-8cae-a75a197844b1.png">
