### PR TITLE
Display yellow status for packages with failed phase under subscription statuses

### DIFF
--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -470,6 +470,7 @@ resource.subscription.local=Subscription deployed on local cluster
 resource.subscription.nostatus.hub= This subscription has no status. If the status does not change to {0} after waiting for initial creation, verify that the multicluster-operators-hub-subscription pod is running on hub.
 resource.subscription.nostatus.remote=This subscription has no status. If the status does not change to {0} after waiting for initial creation, verify that the klusterlet-addon-appmgr pod is running on the remote cluster.
 resource.subscription.placed.error=This subscription was not added to a managed cluster. If this status does not change after waiting for initial creation, ensure the Placement Rule resource is valid and exists in the {0} namespace and that the klusterlet-addon-appmgr pod runs on the managed clusters.
+resource.subscription.status.failed.phase= Some resources failed to deploy. Use View Resource YAML link below to view the details.
 resource.subscription.remote=Remote subscriptions
 resource.subscriptionblocked = Time Window Subscription
 resource.nostatus=No status

--- a/nls/platform.properties
+++ b/nls/platform.properties
@@ -350,6 +350,7 @@ placeholder.filterInput.tags = Add filter tags...
 prop.details.section.service=Service Details
 prop.details.section=Details
 prop.details.section.cluster=Select a cluster to view details
+prop.warning.section=Warning
 
 props.show.argocd.editor=Launch Argo editor
 props.show.local.yaml=View Resource YAML

--- a/src-web/components/Topology/utils/diagram-helpers-utils.js
+++ b/src-web/components/Topology/utils/diagram-helpers-utils.js
@@ -253,6 +253,17 @@ export const getPulseStatusForSubscription = node => {
     pulse = 'yellow' // set to yellow if not placed
   }
 
+  const statuses = _.get(node, 'specs.raw.status.statuses', {})
+  Object.values(statuses).forEach(cluster => {
+    const packageItems = _.get(cluster, 'packages', {})
+    const failedPackage = Object.values(packageItems).find(
+      item => _.get(item, 'phase', '') === 'Failed'
+    )
+    if (failedPackage && pulse === 'green') {
+      pulse = 'yellow'
+    }
+  })
+
   return pulse
 }
 

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -1760,21 +1760,6 @@ export const setSubscriptionDeployStatus = (node, details, activeFilters) => {
             subscription
           )
 
-          // If any packages under subscription statuses has Failed phase, refer user to view resource yaml for more details
-          const statuses = _.get(node, 'specs.raw.status.statuses', {})
-          const clusterStatus = _.get(statuses, subscription.cluster, {})
-          const packageItems = _.get(clusterStatus, 'packages', {})
-          const failedPackage = Object.values(packageItems).find(
-            item => _.get(item, 'phase', '') === 'Failed'
-          )
-          if (failedPackage) {
-            details.push({
-              labelValue: msgs.get('prop.details.section'),
-              value: msgs.get('resource.subscription.status.failed.phase'),
-              status: warningStatus
-            })
-          }
-
           details.push({
             labelValue: subscription.cluster,
             value: subscriptionStatus,
@@ -1788,6 +1773,21 @@ export const setSubscriptionDeployStatus = (node, details, activeFilters) => {
             })
 
           setClusterWindowStatus(windowStatusArray, subscription, details)
+
+          // If any packages under subscription statuses has Failed phase, refer user to view resource yaml for more details
+          const statuses = _.get(node, 'specs.raw.status.statuses', {})
+          const clusterStatus = _.get(statuses, subscription.cluster, {})
+          const packageItems = _.get(clusterStatus, 'packages', {})
+          const failedPackage = Object.values(packageItems).find(
+            item => _.get(item, 'phase', '') === 'Failed'
+          )
+          if (failedPackage) {
+            details.push({
+              labelValue: msgs.get('prop.warning.section'),
+              value: msgs.get('resource.subscription.status.failed.phase'),
+              status: warningStatus
+            })
+          }
 
           details.push({
             type: 'link',

--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -1759,6 +1759,22 @@ export const setSubscriptionDeployStatus = (node, details, activeFilters) => {
           const subscriptionStatus = R.pathOr(emptyStatusErrorMsg, ['status'])(
             subscription
           )
+
+          // If any packages under subscription statuses has Failed phase, refer user to view resource yaml for more details
+          const statuses = _.get(node, 'specs.raw.status.statuses', {})
+          const clusterStatus = _.get(statuses, subscription.cluster, {})
+          const packageItems = _.get(clusterStatus, 'packages', {})
+          const failedPackage = Object.values(packageItems).find(
+            item => _.get(item, 'phase', '') === 'Failed'
+          )
+          if (failedPackage) {
+            details.push({
+              labelValue: msgs.get('prop.details.section'),
+              value: msgs.get('resource.subscription.status.failed.phase'),
+              status: warningStatus
+            })
+          }
+
           details.push({
             labelValue: subscription.cluster,
             value: subscriptionStatus,

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers-utils.test.js
@@ -949,6 +949,59 @@ describe("getPulseStatusForSubscription no subscriptionItem.status", () => {
   });
 });
 
+describe("getPulseStatusForSubscription returns green pulse", () => {
+  const node = {
+    id:
+      "member--subscription--sahar-multins--sahar-multi-sample-subscription-1",
+    name: "mortgagedcNOStatus",
+    specs: {
+      searchClusters: [{ name: "local-cluster", status: "OK" }],
+      raw: { spec: { clustersNames: ["local-cluster"] } },
+      subscriptionModel: {
+        "mortgagedc-subscription-braveman": [{ status: "Subscribed" }],
+        "mortgagedc-subscription-braveman2": [{ status: "Subscribed" }]
+      },
+      row: 12
+    },
+    type: "subscription"
+  };
+
+  it("getPulseStatusForSubscription returns green pulse", () => {
+    expect(getPulseStatusForSubscription(node)).toEqual("green");
+  });
+});
+
+describe("getPulseStatusForSubscription package with Failed phase in statuses", () => {
+  const node = {
+    id:
+      "member--subscription--sahar-multins--sahar-multi-sample-subscription-1",
+    name: "mortgagedcNOStatus",
+    specs: {
+      searchClusters: [{ name: "local-cluster", status: "OK" }],
+      raw: {
+        spec: { clustersNames: ["local-cluster"] },
+        status: {
+          statuses: {
+            "local-cluster": {
+              packages: { "ggithubcom-testrepo-ConfigMap": { phase: "Failed" } }
+            }
+          }
+        }
+      },
+      subscriptionModel: {
+        "mortgagedc-subscription-braveman": [{ status: "Subscribed" }],
+        "mortgagedc-subscription-braveman2": [{ status: "Subscribed" }]
+      },
+      row: 12
+    },
+    type: "subscription"
+  };
+
+  it("getPulseStatusForSubscription return yellow status", () => {
+    expect(getPulseStatusForSubscription(node)).toEqual("yellow");
+  });
+});
+
 describe("getExistingResourceMapKey", () => {
   const resourceMap = {
     "replicaset-nginx-placement-cluster1, cluster2": "test"

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -1596,13 +1596,13 @@ describe("setSubscriptionDeployStatus with Failed phase subscription statuses", 
     { labelKey: "resource.subscription.local", value: "true" },
     { type: "spacer" },
     { labelKey: "resource.deploy.statuses", type: "label" },
+    { labelValue: "local-cluster", status: "checkmark", value: "Subscribed" },
     {
-      labelValue: "Details",
+      labelValue: "Warning",
       status: "warning",
       value:
         "Some resources failed to deploy. Use View Resource YAML link below to view the details."
     },
-    { labelValue: "local-cluster", status: "checkmark", value: "Subscribed" },
     {
       indent: true,
       type: "link",

--- a/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
+++ b/tests/jest/components/Topology/viewer/utils/diagram-helpers.test.js
@@ -1546,6 +1546,83 @@ describe("setSubscriptionDeployStatus with hub error", () => {
   });
 });
 
+describe("setSubscriptionDeployStatus with Failed phase subscription statuses", () => {
+  const node = {
+    type: "subscription",
+    kind: "Subscription",
+    name: "name",
+    namespace: "ns",
+    apiversion: "test",
+    specs: {
+      searchClusters: [
+        {
+          name: "local-cluster",
+          status: "OK"
+        }
+      ],
+      clustersNames: ["local-cluster"],
+      subscriptionModel: {
+        sub1: [
+          {
+            cluster: "local-cluster",
+            status: "Subscribed",
+            _hubClusterResource: "true"
+          }
+        ]
+      },
+      raw: {
+        apiVersion: "test",
+        spec: {
+          placement: {
+            local: true
+          }
+        },
+        status: {
+          statuses: {
+            "local-cluster": {
+              packages: {
+                "ggithubcom-testrepo-ConfigMap": {
+                  phase: "Failed"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+  const response = [
+    { type: "spacer" },
+    { labelKey: "resource.subscription.local", value: "true" },
+    { type: "spacer" },
+    { labelKey: "resource.deploy.statuses", type: "label" },
+    {
+      labelValue: "Details",
+      status: "warning",
+      value:
+        "Some resources failed to deploy. Use View Resource YAML link below to view the details."
+    },
+    { labelValue: "local-cluster", status: "checkmark", value: "Subscribed" },
+    {
+      indent: true,
+      type: "link",
+      value: {
+        data: {
+          action: "show_resource_yaml",
+          cluster: "local-cluster",
+          editLink: "/resources?cluster=local-cluster"
+        },
+        label: "View Resource YAML"
+      }
+    },
+    { type: "spacer" },
+    { type: "spacer" }
+  ];
+  it("setSubscriptionDeployStatus with Failed phase subscription statuses", () => {
+    expect(setSubscriptionDeployStatus(node, [], {})).toEqual(response);
+  });
+});
+
 describe("setSubscriptionDeployStatus with no sub error", () => {
   const node = {
     type: "subscription",

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -425,6 +425,7 @@
   "resource.subscription.nostatus.hub": "This subscription has no status. If the status does not change to {0} after waiting for initial creation, verify that the multicluster-operators-hub-subscription pod is running on hub.",
   "resource.subscription.nostatus.remote": "This subscription has no status. If the status does not change to {0} after waiting for initial creation, verify that the klusterlet-addon-appmgr pod is running on the remote cluster.",
   "resource.subscription.placed.error": "This subscription was not added to a managed cluster. If this status does not change after waiting for initial creation, ensure the Placement Rule resource is valid and exists in the {0} namespace and that the klusterlet-addon-appmgr pod runs on the managed clusters.",
+  "resource.subscription.status.failed.phase": "Some resources failed to deploy. Use View Resource YAML link below to view the details.",
   "resource.subscription.remote": "Remote subscriptions",
   "resource.subscriptionblocked": "Time Window Subscription",
   "resource.nostatus": "No status",

--- a/tests/jest/config/platform-properties.json
+++ b/tests/jest/config/platform-properties.json
@@ -310,6 +310,7 @@
   "prop.details.section.service": "Service Details",
   "prop.details.section": "Details",
   "prop.details.section.cluster": "Select a cluster to view details",
+  "prop.warning.section": "Warning",
   "props.show.argocd.editor": "Launch Argo editor",
   "props.show.local.yaml": "View Resource YAML",
   "props.show.log": "View Pod YAML and Logs",


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

https://github.com/open-cluster-management/backlog/issues/10652

<img width="945" alt="Screen Shot 2021-05-07 at 1 07 13 PM" src="https://user-images.githubusercontent.com/11761226/117484631-5a6aac80-af35-11eb-9b66-3f885292b34c.png">

<img width="913" alt="Screen Shot 2021-05-07 at 1 08 04 PM" src="https://user-images.githubusercontent.com/11761226/117484633-5b9bd980-af35-11eb-8763-d4a799e99bf5.png">

