### PR TITLE
Fix cronjob icon and remove policy node title

### DIFF
--- a/src-web/components/Topology/viewer/defaults/shapes.js
+++ b/src-web/components/Topology/viewer/defaults/shapes.js
@@ -37,10 +37,6 @@ export const defaultShapes = Object.freeze({
     shape: 'container',
     className: 'container'
   },
-  cronjob: {
-    shape: 'clock',
-    className: 'default'
-  },
   customresource: {
     shape: 'customresource',
     className: 'container'

--- a/src-web/components/Topology/viewer/defaults/titles.js
+++ b/src-web/components/Topology/viewer/defaults/titles.js
@@ -13,15 +13,8 @@
 import msgs from '../../../../../nls/platform.properties'
 import _ from 'lodash'
 
-export const getNodeTitle = (node, locale) => {
-  const { type } = node
-  switch (type) {
-  case 'policy':
-    return msgs.get('topology.title.policy', locale)
-
-  default:
-    return _.get(node, 'specs.title', '')
-  }
+export const getNodeTitle = node => {
+  return _.get(node, 'specs.title', '')
 }
 
 export const getSectionTitles = (clusters, types, environs, locale) => {

--- a/src-web/components/Topology/viewer/helpers/layoutHelper.js
+++ b/src-web/components/Topology/viewer/helpers/layoutHelper.js
@@ -102,7 +102,7 @@ export default class LayoutHelper {
     nodes.forEach(node => {
       if (node.layout) {
         if (this.getNodeTitle) {
-          node.layout.title = this.getNodeTitle(node, this.locale)
+          node.layout.title = this.getNodeTitle(node)
         }
         if (this.getNodeDescription) {
           node.layout.description = this.getNodeDescription(node)


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12530

- Cronjob icon displays properly
- The `policy` text that used to display above the policy nodes is removed for consistency with other nodes

<img width="1660" alt="image" src="https://user-images.githubusercontent.com/38960034/118326862-8b1d8980-b4d3-11eb-80e2-43468829148c.png">
