### PR TITLE
Disable shape replacement in filtering

### DIFF
--- a/src-web/components/Topology/viewer/defaults/filtering.js
+++ b/src-web/components/Topology/viewer/defaults/filtering.js
@@ -138,19 +138,6 @@ export const getAllFilters = (
       .sort()
   }
 
-  // if lots of unknown types, assign some unknown types to spare shapes
-  if (unknownTypes.length > 3 && availableTypes.length < 3) {
-    const set = new Set(unknownTypes)
-    sorted.filter(a => set.has(a)).some((a, idx) => {
-      const spareKey = `spare${idx + 1}`
-      typeToShapeMap[a] = typeToShapeMap[spareKey]
-      availableTypes.push(a)
-      otherTypeFilters = otherTypeFilters.filter(b => a !== b)
-      delete typeToShapeMap[spareKey]
-      return idx >= 5 // only 5 spares
-    })
-  }
-
   // if there are still other shapes, add to available
   if (otherTypeFilters.length > 0) {
     availableTypes = _.union(availableTypes, ['other'])


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/12811

- Removed code in filtering.js that was replacing shapes if unknowntype count was above 3

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/38960034/119573121-d2343600-bd81-11eb-8c0f-f4957b9c6968.png">
