### PR TITLE
update to latest temptifly version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6173,7 +6173,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -7594,7 +7595,8 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -8286,16 +8288,6 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -8333,7 +8325,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -9985,7 +9978,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -14050,11 +14044,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-    },
     "ip-address": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
@@ -14224,6 +14213,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -17198,14 +17188,6 @@
         "readable-stream": "^2.0.5"
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -19385,7 +19367,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -19606,14 +19589,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "^1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -23494,6 +23469,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -23603,6 +23579,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -23961,9 +23938,9 @@
       }
     },
     "temptifly": {
-      "version": "0.3.32",
-      "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.3.32.tgz",
-      "integrity": "sha512-bXzxxSv1M8lZk6AAQ07g+TFRaY+w5GkFVE+CaPsShqPmkAxcZSP8k5GHF892FPJn3fze2sN3BDp+keUBYbeN9Q==",
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.3.36.tgz",
+      "integrity": "sha512-S+m2mCOd0IDqk4BKf0biYurHYoquSfBGOMybWv89v5IIkKCJF8nxQI7bZfAzxoYRWvzeRrczbVWCrxD1dy5COg==",
       "requires": {
         "@loadable/component": "^5.14.1",
         "apollo-client": "^2.2.8",
@@ -23975,7 +23952,7 @@
         "js-yaml": "^3.13.1",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.18",
-        "nconf": "^0.10.0",
+        "nconf": "^0.11.2",
         "null-loader": "^3.0.0",
         "prop-types": "^15.6.1",
         "react-apollo": "^2.3.1",
@@ -23983,33 +23960,12 @@
         "react-split-pane": "^0.1.92"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
         "graphql": {
           "version": "0.13.2",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
           "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
           "requires": {
             "iterall": "^1.2.1"
-          }
-        },
-        "ini": {
-          "version": "1.3.8",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-        },
-        "nconf": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-          "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-          "requires": {
-            "async": "^1.4.0",
-            "ini": "^1.3.0",
-            "secure-keys": "^1.0.0",
-            "yargs": "^3.19.0"
           }
         }
       }
@@ -25984,11 +25940,6 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -26007,15 +25958,6 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
-      }
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -26111,11 +26053,6 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
-    "y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -26134,20 +26071,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "glob": "^7.0.5"
-      }
-    },
-    "yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-      "requires": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "svg-loader": "0.0.2",
     "svg-react-loader": "^0.4.6",
     "svg.js": "^2.6.5",
-    "temptifly": "^0.3.32",
+    "temptifly": "^0.3.36",
     "watchr": "^4.0.1",
     "webpack-sources": "^1.1.0",
     "yaml": "^1.7.2",


### PR DESCRIPTION
Signed-off-by: Richie Piya <rpiyasirisilp@gmail.com>

update to temptifly 0.3.36 (changes from PR: https://github.com/open-cluster-management/temptifly/pull/85)

Fixes
-

https://github.com/open-cluster-management/backlog/issues/12941
- trims extra spaces in url section

https://github.com/open-cluster-management/backlog/issues/12537
- fix yaml editor sizing when toggling sidebar

https://github.com/open-cluster-management/backlog/issues/12280
- left align wizard content
<img width="1100" alt="Screen Shot 2021-06-01 at 1 54 55 PM" src="https://user-images.githubusercontent.com/39634227/120492060-c18a4e00-c387-11eb-9352-1002ec8796cc.png">
