### PR TITLE
Fix subscription propagated status icon in details

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -76,7 +76,8 @@ const resSuccessStates = [
   'run',
   'bound',
   deployedStr.toLowerCase(),
-  deployedNSStr.toLowerCase()
+  deployedNSStr.toLowerCase(),
+  'propagated'
 ]
 const apiVersionPath = 'specs.raw.apiVersion'
 


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>
https://github.com/open-cluster-management/backlog/issues/12970

- Added `propagated` as one of the success statuses to check for

The subscription propagated status now displays with a success icon:
<img width="1644" alt="image" src="https://user-images.githubusercontent.com/38960034/120550564-07b0d300-c3c3-11eb-9372-8689ca407351.png">
