### PR TITLE
fix slack failure to send video

### DIFF
--- a/tests/cypress/scripts/slack-reporter.js
+++ b/tests/cypress/scripts/slack-reporter.js
@@ -121,7 +121,7 @@ async function postVideo(fileName, filePath, comment, userId) {
       initial_comment: comment
     });
   } catch (e) {
-    console.error("Slack Post Error", e);
+    console.log("Slack Post Error", e);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: chenz4027 <magchen@redhat.com>

Change console.error to console.log to allow e2e-cluster to send videos to slack user.

Tested in https://github.com/open-cluster-management/application-ui/pull/1289

![image](https://user-images.githubusercontent.com/26282541/122291655-0dc6a980-cec3-11eb-84c6-3a87c330ca3d.png)
![image](https://user-images.githubusercontent.com/26282541/122291669-128b5d80-cec3-11eb-9827-b7816aefd852.png)
