### PR TITLE
Implement support for ROSA IDP

### DIFF
--- a/tests/cypress/config/users.yaml
+++ b/tests/cypress/config/users.yaml
@@ -3,7 +3,7 @@ users:
   # Users are based on the roles defined in RBAC Test specification
   # Mapping is userRole: username
 
-  cluster-admin: test-cluster-admin
+  cluster-admin-app: test-cluster-admin
   #cluster-admin / cluster-wide
 
   cluster-manager-admin: test-cluster-manager-admin

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -273,7 +273,8 @@ Cypress.Commands.add("ocLogin", role => {
   );
   const { users } = Cypress.env("USER_CONFIG");
   let user;
-  if (role !== "kubeadmin") {
+  // cluster-admin is used by ROSA so we can't use that anymore
+  if (role !== "kubeadmin" && role !== "cluster-admin") {
     cy.addUserIfNotCreatedBySuite();
     user = users[role];
     if (!user) {
@@ -287,6 +288,10 @@ Cypress.Commands.add("ocLogin", role => {
       `Role is not kubeadmin, adding user=${user} to Cypress.env("OC_CLUSTER_USER"), which is the users[${role}]`
     );
   }
+  // set user to cluster-admin when running on ROSA
+  if (role === "cluster-admin") {
+    user = role;
+  }
   cy.log("OC_CLUSTER_USER", Cypress.env("OC_CLUSTER_USER"));
 
   const loginUserDetails = {
@@ -294,6 +299,7 @@ Cypress.Commands.add("ocLogin", role => {
     user: user || "kubeadmin",
     password: Cypress.env("OC_CLUSTER_PASS")
   };
+
   // Workaround for "error: x509: certificate signed by unknown authority" problem with oc login
   let certificateAuthority = "";
   if (Cypress.env("OC_CLUSTER_INGRESS_CA")) {


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13325

- Change the `cluster-admin` to `cluster-admin-app` since this is conflicting with the role provided by ROSA
- Added check for `cluster-admin` so we don't need to create that user

We're getting permission denied when running on ROSA, and the user being used is `test-cluster-admin`:
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/38960034/122469498-079c0000-cf8b-11eb-965c-5d68aee2265e.png">

In our code, we only use `test-cluster-manager-admin` so my assumption is that the role provided by ROSA is causing the issue and we should handle it the same way we handle `kubeadmin`.