### PR TITLE
Filter out helm properties for search query

### DIFF
--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -464,7 +464,10 @@ const fetchArgoApplications = (
   } else {
     for (const [property, value] of Object.entries(appData.source)) {
       // add argo app source filters
-      query.filters.push({ property, values: [value] })
+      if (property !== 'helm') {
+        // skip helm as that contains non string values that graphql can't handle
+        query.filters.push({ property, values: [value] })
+      }
     }
   }
   apolloClient


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>
https://github.com/open-cluster-management/backlog/issues/13532

- Filter out helm properties for search query since they contain non string values which are not supported

The UI doesn't crash anymore and displays the app status:

<img width="1641" alt="image" src="https://user-images.githubusercontent.com/38960034/122822803-8f944980-d2ac-11eb-8001-31fae242c7ee.png">
