### PR TITLE
Check for targetRevision and default to HEAD if it doesn't exist

### DIFF
--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -465,12 +465,16 @@ const fetchArgoApplications = (
     let targetRevisionFound = false
     for (const [property, value] of Object.entries(appData.source)) {
       // add argo app source filters
+      let propValue = value
       if (property === 'targetRevision') {
         targetRevisionFound = true
+        if (propValue.length === 0) {
+          propValue = 'HEAD'
+        }
       }
       if (property !== 'helm') {
         // skip helm as that contains non string values that graphql can't handle
-        query.filters.push({ property, values: [value] })
+        query.filters.push({ property, values: [propValue] })
       }
     }
 

--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -462,12 +462,20 @@ const fetchArgoApplications = (
     })
     query.filters.push({ property: 'namespace', values: [appNS] })
   } else {
+    let targetRevisionFound = false
     for (const [property, value] of Object.entries(appData.source)) {
       // add argo app source filters
+      if (property === 'targetRevision') {
+        targetRevisionFound = true
+      }
       if (property !== 'helm') {
         // skip helm as that contains non string values that graphql can't handle
         query.filters.push({ property, values: [value] })
       }
+    }
+
+    if (!targetRevisionFound) {
+      query.filters.push({ property: 'targetRevision', values: ['HEAD'] })
     }
   }
   apolloClient


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://github.com/open-cluster-management/backlog/issues/13638

- When constructing the search query check for targetRevision and default to `HEAD` if it doesn't exist

With the patch in `search-collector`, we can now see the related apps for `helloworld-argo-app-3`:
<img width="1644" alt="image" src="https://user-images.githubusercontent.com/38960034/123287524-c781d380-d4dc-11eb-9c73-53653807d22d.png">
