### PR TITLE
Fix UI crash from node details

### DIFF
--- a/src-web/components/Topology/viewer/defaults/details.js
+++ b/src-web/components/Topology/viewer/defaults/details.js
@@ -209,7 +209,9 @@ function addK8Details(node, updatedNode, details, activeFilters) {
     if (resourceModel) {
       // get first item in the object as all should have the same labels
       const resourceLabels =
-        resourceModel[Object.keys(resourceModel)[0]][0].label
+        Object.keys(resourceModel).length > 0
+          ? resourceModel[Object.keys(resourceModel)[0]][0].label
+          : undefined
       labels = resourceLabels ? resourceLabels.replace('; ', ',') : 'No labels'
     } else {
       labels = 'No labels'


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/14008

- Added a check to make sure array is not empty

The UI doesn't crash anymore and displays the node details:
<img width="1638" alt="image" src="https://user-images.githubusercontent.com/38960034/124657839-0155c100-de71-11eb-947f-2b8f1a530094.png">
