### PR TITLE
Fix Argo app topology not loading search data for 2.4

### DIFF
--- a/src-web/actions/topology.js
+++ b/src-web/actions/topology.js
@@ -463,7 +463,13 @@ const fetchArgoApplications = (
     query.filters.push({ property: 'namespace', values: [appNS] })
   } else {
     let targetRevisionFound = false
-    for (const [property, value] of Object.entries(appData.source)) {
+    const searchProperties = _.pick(appData.source, [
+      'repoURL',
+      'path',
+      'chart',
+      'targetRevision'
+    ])
+    for (const [property, value] of Object.entries(searchProperties)) {
       // add argo app source filters
       let propValue = value
       if (property === 'targetRevision') {
@@ -472,10 +478,8 @@ const fetchArgoApplications = (
           propValue = 'HEAD'
         }
       }
-      if (property !== 'helm') {
-        // skip helm as that contains non string values that graphql can't handle
-        query.filters.push({ property, values: [propValue] })
-      }
+
+      query.filters.push({ property, values: [propValue] })
     }
 
     if (!targetRevisionFound) {


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/14406

- Only allow certain properties to be set for the search query

The topology displays the search data now:
<img width="1643" alt="image" src="https://user-images.githubusercontent.com/38960034/126383082-9d6d16da-b672-4bd3-aa2a-2306d36193f2.png">