### PR TITLE
update ui-components with header without VWT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-cluster-management/application-ui",
-  "version": "2.1.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4952,13 +4952,13 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
-      "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+      "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/styles": "^4.11.4",
-        "@material-ui/system": "^4.11.3",
+        "@material-ui/system": "^4.12.1",
         "@material-ui/types": "5.1.0",
         "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
@@ -5044,9 +5044,9 @@
       }
     },
     "@material-ui/system": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
-      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+      "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/utils": "^4.11.2",
@@ -5141,9 +5141,9 @@
       }
     },
     "@open-cluster-management/ui-components": {
-      "version": "0.179.0",
-      "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-0.179.0.tgz",
-      "integrity": "sha512-SR81EpGvaGU4b5LTsRoM9W/nYJR3iiizIaO68v8uSnULY6KEWHblDFMocMAFA+91ngH/d8NiQU9Qu6j7Kavf7Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-1.1.0.tgz",
+      "integrity": "sha512-Nfn5m6ky9NBy6wUYlZCMDzWeDikeEE2aNtdB5PamAsMedvJ6ipnWWMb2QCZdgO2x51F+DpywPd8sU5yJkyJK8g==",
       "requires": {
         "@material-ui/core": "^4.11.4",
         "@material-ui/styles": "^4.11.4",
@@ -5157,7 +5157,7 @@
         "moment": "^2.29.1",
         "nock": "^13.1.0",
         "react-router-dom": "^5.2.0",
-        "react-tag-autocomplete": "^6.1.0"
+        "react-tag-autocomplete": "6.1.0"
       },
       "dependencies": {
         "get-value": {
@@ -5628,9 +5628,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -18957,9 +18957,9 @@
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
     "nock": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.0.tgz",
-      "integrity": "sha512-3N3DUY8XYrxxzWazQ+nSBpiaJ3q6gcpNh4gXovC/QBxrsvNp4tq+wsLHF6mJ3nrn3lPLn7KCJqKxy/9aD+0fdw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.1.tgz",
+      "integrity": "sha512-YKTR9MjfK3kS9/l4nuTxyYm30cgOExRHzkLNhL8nhEUyU4f8Za/dRxOqjhVT1vGs0svWo3dDnJTUX1qxYeWy5w==",
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -18968,9 +18968,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -24791,66 +24791,66 @@
       }
     },
     "victory-area": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.9.0.tgz",
-      "integrity": "sha512-vUlQoVNl4l2SsPwx7Rf8YkDpDVCrRv5t+Zde8kvo211em9FaROfWQvDcha48hRPH9v/AeH19whMWMgCdDsx/rA==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.10.0.tgz",
+      "integrity": "sha512-TgaBLDDjDEvEiOj+y8eqEnbUwXwgRnGwQnt1wxFJLcl6lVS3duuPi7tPIsQ0nD0enCTr9P2LQlbuh3NnFter4g==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-axis": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.9.0.tgz",
-      "integrity": "sha512-i54nlB4F3i7QklkuIUli9PzaIjYZ87pxvOdokqggjxEZCyxF4g2zGa1sm/4K6o5i34W+Ce01TIOaYyW3L92Byg==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.10.0.tgz",
+      "integrity": "sha512-yv5cCfl58pxF1g+vpWYySuvNdMflFZWyyV/ZqC6q+vv9REu0cvkUXF8XPrM5kSBMhx1bFwcELRxjiHmEajSO8g==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-bar": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.9.0.tgz",
-      "integrity": "sha512-IjqzsJ60cCH/kXpmmlfCshwttNJGjlQs8khr/R5IzOg5bN0y6XO2roW9sWnXLdSt6pUB2z4t9tJ9gOOBADLB7A==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.10.0.tgz",
+      "integrity": "sha512-FTBw4BcXSE3uHjQdUg+xxm7F6Tsr2B/yCLPtC/LGRphQ9aGYgrGB+S4ReGrXFPQ73d/hHs/BYDK9eMUnBXMwRQ==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-brush-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.9.0.tgz",
-      "integrity": "sha512-34vd/T2jyugXSM3KZGGUarnjblptVTh/Z2cQuMCW7nPws3cqlpOut3bQmayPePyUPPp6UbI4/uaRfw+u8TTMlQ==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.10.0.tgz",
+      "integrity": "sha512-7R82+jVtNtTNYYgy5qBWYknCIPdr60YaO6gFOmy4WSmhDr/saNWHMslheaMoGGsCzCKjBrrEk89Poz91bQRORg==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-chart": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.9.0.tgz",
-      "integrity": "sha512-TIk8Ipij28UWzJky+cnjhCVhRqwbg6eDylOXLXxTAW6hPeZAhvfJSfnv/PZb5gq8kPiDklfK6sN3RSmYugHqHg==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.10.0.tgz",
+      "integrity": "sha512-NZ5atgYlhFvft1Tq9SY2PK9eX3LeEpvrAiw6UEzLBTQI7e1bbHgqls9J23NG5+jNcbGQR/ZHYuHRr1PvUuOelw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-axis": "^35.9.0",
-        "victory-core": "^35.9.0",
-        "victory-polar-axis": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-axis": "^35.10.0",
+        "victory-core": "^35.10.0",
+        "victory-polar-axis": "^35.10.0",
+        "victory-shared-events": "^35.10.0"
       }
     },
     "victory-core": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.9.0.tgz",
-      "integrity": "sha512-t949a5U/p3fzMalcIAjcNexqj16e5kSyL+F0f6mamZZRy7ShhcyCqT4tm/rlog3cNpm/3gYnTWttiWrAulEoHg==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.10.0.tgz",
+      "integrity": "sha512-opsGKB9J+g6MSPq2EsomcVfSuCJQdVyUpBtp8IA8lGBdnY4+K3QAFrjxcRBhqKklH8sG+cKiD9/PSaCO8Ud4Tg==",
       "requires": {
         "d3-ease": "^1.0.0",
         "d3-interpolate": "^1.1.1",
@@ -24863,158 +24863,158 @@
       }
     },
     "victory-create-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.9.0.tgz",
-      "integrity": "sha512-yC5NOA9LswYOxG6VXwPE1y2lSzYoKSovJO2MKwKmhXUzJtUJMtju67Y/d2VFkYTJMDC8LUW+9AEP6mrZ45wvDA==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.10.0.tgz",
+      "integrity": "sha512-NcGSoPuM+oqd2xUGBtvFbOVPuPhhuhlw02ChPhMh8sT7Cm91tT/QzN6IKBsMzRmNi8KHVipbRh9kvCkMy51kNg==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^35.9.0",
-        "victory-core": "^35.9.0",
-        "victory-cursor-container": "^35.9.0",
-        "victory-selection-container": "^35.9.0",
-        "victory-voronoi-container": "^35.9.0",
-        "victory-zoom-container": "^35.9.0"
+        "victory-brush-container": "^35.10.0",
+        "victory-core": "^35.10.0",
+        "victory-cursor-container": "^35.10.0",
+        "victory-selection-container": "^35.10.0",
+        "victory-voronoi-container": "^35.10.0",
+        "victory-zoom-container": "^35.10.0"
       }
     },
     "victory-cursor-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.9.0.tgz",
-      "integrity": "sha512-rOct5asJ/LjmbS+AFlY4WRv7vVacumdp6zrJrPCAjT4AF+6bpcN0Im9GVcAiSa88gqf/EYpBa3txnf9wLnikFw==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.10.0.tgz",
+      "integrity": "sha512-UwqckpHyGGl9U3p0yDlK8sFsoUgw0F1s0mAeLzUN1S8sflZJ26jGangIo+XiltyzYT9EJ51L8daR45+4ituyrw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-group": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.9.0.tgz",
-      "integrity": "sha512-5ynuM2dO0dnjakcjVjs9lDohbXZ5VpI0O7qF1iK51rdh4JCN4vMhJ+dcHX/uECJ9AntxQETwbcqyJYN1n2O4SA==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.10.0.tgz",
+      "integrity": "sha512-jEMSeO/CeZFGcGZIrviUmwF9m2dXUhc+5BZpczXu+i4/5jlo/yZZeCy22HwAM0QL+EUkPRb+IVg5MpZCVNz7cA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-core": "^35.10.0",
+        "victory-shared-events": "^35.10.0"
       }
     },
     "victory-legend": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.9.0.tgz",
-      "integrity": "sha512-JGbMH14XERP+0v6OLbfhUuYrZs7+nQDwtO3xJ/oozuFBcC1tPaMXqNgHUb986CGttrw2fG8g8bRahYZy5YdJuQ==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.10.0.tgz",
+      "integrity": "sha512-njQglXYX4JkhXMDIWpGQPEO1U9gNQ0iOUT41U7KhMc8SO4x4gPaNUWBMEpHIXXQlUYOAOUNwlPSzD4ekOcIQBA==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-line": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.9.0.tgz",
-      "integrity": "sha512-CeAUZpdBd7zETWGqEWfKuyP643Y66FjcdgYcfdLhO8IBwyFOnWuvLadsrtvAXz7XuUhi59G1kOgzWmuvPp4a/Q==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.10.0.tgz",
+      "integrity": "sha512-jIkuprzbNc2v07y9qdG/K8cNTFrg80Qi3rCBElD6DzWwdQgn7dlXVYov4lDR0Mm76RBI1c2RutzlBpBADRqQuQ==",
       "requires": {
         "d3-shape": "^1.2.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-pie": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.9.0.tgz",
-      "integrity": "sha512-xT4A2ltGLnj26uliVDfNFjEVcAzuDRzM6zZqoN4T7gDZOIus5LOLL/SwTnKpMmzqKcp9fybZmuWDMIxTZvsL4A==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.10.0.tgz",
+      "integrity": "sha512-jDYTAhLyT01vgTjejmQFYDNiw7CVbn+2jID0dKm+7OKjScyDPlCbDhTyXdB0xhbkCjxunFIPN49wxs/eIlg5wA==",
       "requires": {
         "d3-shape": "^1.0.0",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-polar-axis": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.9.0.tgz",
-      "integrity": "sha512-dKEic/vr2FL3d3JtL4DcWAcxnrC6a/j2GPvDkby2aMimLMf5z8zZgr1/KQ3Xru40J4I6ML0Bvdm/1kNRyOq6sA==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.10.0.tgz",
+      "integrity": "sha512-wigYkGEZcf0e9zGM/YwtNfanjjUAexAyhlqZ9fmJgpCKMZQDk1a4z579w18iRoyX/UOq42a3K9PstrgsGrXeeg==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-scatter": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.9.0.tgz",
-      "integrity": "sha512-xbltDOzLxdGDwdzEHjzz/9r2t0g2TZzudzIQuTfuJiUBy6gzfeTMGliLLJFPzonp48CElUtJUHe6wuvNeai6sQ==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.10.0.tgz",
+      "integrity": "sha512-J9pmvGispvEquRfQx1QvfWODiYcToN0sXzQ4hqWC9jZJLzGiLKObGkI88HCr7PHTJFOG5JwG1EYmcp+mE75IUw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-selection-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.9.0.tgz",
-      "integrity": "sha512-/DRkvAkfI4DGOELJDrIsU3GYozH+lwcXu56p3hD03VVa2xmM+ek7e/wzFZvlLAczRuilOgO54BYZ6rU/cQDmVg==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.10.0.tgz",
+      "integrity": "sha512-8CyQf6munSMmMD/zuOmeT5s0v8dm9KXfhq4haQY0XlDjQ3N6rNFbEkWuORiS4Z0cUET7obKWaSJUUoAFkanMIg==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-shared-events": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.9.0.tgz",
-      "integrity": "sha512-5DFaZ3DZnyAAl+Dmkq0bzAskw0cXonF7rFz4PLtQxUQfqOXwmABvyrJ43sqzzApdRoNHWuYibqAEqEiDE5kQjQ==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.10.0.tgz",
+      "integrity": "sha512-M8P+CR6oJq86ylHnkkHzkEBSvwe1ls6kvqkNsuQL14l0SnUwh3Fu/oZ2dD7hK5kRF01rzEdn6Ma35B0qUPJyqw==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-stack": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.9.0.tgz",
-      "integrity": "sha512-b7DNisxEqJybs2UF2VJ9Tf7zctTcfgQMwU4LY4JfIIbvNEArKAe7si1ezb2DaiZvgYg7fnB/6iR/X8ixKMHw/Q==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.10.0.tgz",
+      "integrity": "sha512-xXCsQREJCyIotShm2F7Am/O8r3ogUrJQafyXu8mLBTPXYI+kHjMGVOXcSvKKjNaGKQE8staNzkoMxpacWFLCsw==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-shared-events": "^35.9.0"
+        "victory-core": "^35.10.0",
+        "victory-shared-events": "^35.10.0"
       }
     },
     "victory-tooltip": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.9.0.tgz",
-      "integrity": "sha512-Jj4Y/HQbkWs4v+kjJCs/eVWlzckIwV3gcGSy0HJvv03sXVf2mwFEAGS7/F4IOCaJGcsJlTC4m30yB+nhZgqlgQ==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.10.0.tgz",
+      "integrity": "sha512-ajTR34bSxAeF6ySjn6Qk3mwoVA9NUPYtPIqNw6IGpyh9sC4K8J37MLqcwM1/DM2aevSISartfejiG6/Kn/bZOg==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "victory-voronoi-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.9.0.tgz",
-      "integrity": "sha512-T95+eR0tjj9vAzzGk/c/PiJ0xunMsDzSa912zMExt+fDDtVXfd0xO9ji1qSWZldZo9spUUxyg01DK/X2VVsKow==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.10.0.tgz",
+      "integrity": "sha512-MSZq6XY2sArASDkW5a5xA8oSg+SI0mRK86VwFTC4v0fHfRMHMCxusxaKQXVOtaTskcRVXgFm59yvB3S7w+wECA==",
       "requires": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^35.9.0",
-        "victory-tooltip": "^35.9.0"
+        "victory-core": "^35.10.0",
+        "victory-tooltip": "^35.10.0"
       }
     },
     "victory-zoom-container": {
-      "version": "35.9.0",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.9.0.tgz",
-      "integrity": "sha512-OFFy4KPwUvx7IUbOmgECkvv0ihaCvZEVbPaKTkpDUCQa4YLRosL9j5gP9JdcGXYs2E3cssS1lgKiVsqzher9eA==",
+      "version": "35.10.0",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.10.0.tgz",
+      "integrity": "sha512-CyAZy5IUp1aWz2LxOnMaTUBLtpgQvq5nFjvjfXZyigXE64jeE4+/pm4B6+4wihK/8MhPGwBiON2i3RoneQulew==",
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.5.8",
-        "victory-core": "^35.9.0"
+        "victory-core": "^35.10.0"
       }
     },
     "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/register": "^7.12.1",
     "@loadable/component": "^5.14.1",
     "@open-cluster-management/security-middleware": "^1.0.2",
-    "@open-cluster-management/ui-components": "^0.179.0",
+    "@open-cluster-management/ui-components": "^1.1.0",
     "@patternfly/patternfly": "^4.115.2",
     "@patternfly/react-core": "^4.135.0",
     "@patternfly/react-icons": "^4.11.0",

--- a/tests/jest/components/AdvancedConfigurationPage/__snapshots__/AdvancedConfigurationPage.test.js.snap
+++ b/tests/jest/components/AdvancedConfigurationPage/__snapshots__/AdvancedConfigurationPage.test.js.snap
@@ -161,7 +161,7 @@ exports[`AdvancedConfigurationPage renders the Channels table correctly 1`] = `
             class="pf-l-stack__item"
           >
             <div
-              class="MuiCollapse-container"
+              class="MuiCollapse-root"
               style="min-height: 0px; height: 0px; transition-duration: 150ms;"
             >
               <div
@@ -1357,7 +1357,7 @@ exports[`AdvancedConfigurationPage renders the Placement rules table correctly 1
             class="pf-l-stack__item"
           >
             <div
-              class="MuiCollapse-container"
+              class="MuiCollapse-root"
               style="min-height: 0px; height: 0px; transition-duration: 150ms;"
             >
               <div
@@ -2484,7 +2484,7 @@ exports[`AdvancedConfigurationPage renders the Subscriptions table correctly 1`]
             class="pf-l-stack__item"
           >
             <div
-              class="MuiCollapse-container"
+              class="MuiCollapse-root"
               style="min-height: 0px; height: 0px; transition-duration: 150ms;"
             >
               <div

--- a/tests/jest/components/__snapshots__/ApplicationsListPage.test.js.snap
+++ b/tests/jest/components/__snapshots__/ApplicationsListPage.test.js.snap
@@ -15,7 +15,7 @@ exports[`ApplicationsListPage ApplicationsListPage renders correctly with data o
           class="pf-l-stack__item"
         >
           <div
-            class="MuiCollapse-container"
+            class="MuiCollapse-root"
             style="min-height: 0px; height: 0px; transition-duration: 150ms;"
           >
             <div
@@ -1070,7 +1070,7 @@ exports[`ApplicationsListPage ApplicationsListPage renders correctly with data o
           class="pf-l-stack__item"
         >
           <div
-            class="MuiCollapse-container"
+            class="MuiCollapse-root"
             style="min-height: 0px; height: 0px; transition-duration: 150ms;"
           >
             <div
@@ -2125,7 +2125,7 @@ exports[`ApplicationsListPage ApplicationsListPage renders correctly with data o
           class="pf-l-stack__item"
         >
           <div
-            class="MuiCollapse-container"
+            class="MuiCollapse-root"
             style="min-height: 0px; height: 0px; transition-duration: 150ms;"
           >
             <div


### PR DESCRIPTION
Signed-off-by: Mark Anderson <markande@redhat.com>

Update `ui-components` to v1.1.0 to get version of AcmHeader without links to Visual Web Terminal.  Change for story https://github.com/open-cluster-management/backlog/issues/14732