### PR TITLE
Fix canary 403 forbidden error

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -340,7 +340,8 @@ Cypress.Commands.add("logInAsRole", role => {
         }
       });
   };
-  cy.visit("/oauth/start?rd=/");
+  cy.visit("/multicloud/applications", { failOnStatusCode: false });
+
   cy.get("body").then(body => {
     if (body.find(".pf-c-page__header").length !== 0) {
       cy.log(

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -340,7 +340,7 @@ Cypress.Commands.add("logInAsRole", role => {
         }
       });
   };
-  cy.visit("/multicloud/applications");
+  cy.visit("/oauth/start?rd=/");
   cy.get("body").then(body => {
     if (body.find(".pf-c-page__header").length !== 0) {
       cy.log(


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/15429

- Changed e2e tests to login by visiting `oauth/start?rd=/` instead of `/multicloud/applications`