### PR TITLE
Add cypress-fail-fast to skip other tests

### DIFF
--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -38,11 +38,6 @@ const getUsers = require("../config").getUsers();
 const rbacConfig = require("../config").getrbacConfig();
 
 module.exports = (on, config) => {
-  require("cypress-fail-fast/plugin")(on, config);
-  return config;
-};
-
-module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 
@@ -130,6 +125,8 @@ module.exports = (on, config) => {
   )
     ? "true"
     : "";
+
+  require("cypress-fail-fast/plugin")(on, config);
 
   return config;
 };

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -38,6 +38,11 @@ const getUsers = require("../config").getUsers();
 const rbacConfig = require("../config").getrbacConfig();
 
 module.exports = (on, config) => {
+  require("cypress-fail-fast/plugin")(on, config);
+  return config;
+};
+
+module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -30,6 +30,7 @@ import "./useradd";
 import "./ansibleoperator";
 import "./argocdoperator";
 import "./createsecret";
+import "cypress-fail-fast";
 
 // import '@cypress/code-coverage/support'
 

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -732,6 +732,36 @@
         }
       }
     },
+    "cypress-fail-fast": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cypress-fail-fast/-/cypress-fail-fast-3.1.1.tgz",
+      "integrity": "sha512-UKW4IUZG85RoETEzx2uH0dD+j6QVUHkyWRwop8Uzug2g4K/IEid0SeS/kgua9pCxeKe2IRHBzcT0FnOBfhRBNA==",
+      "dev": true,
+      "requires": {
+        "chalk": "4.1.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "cypress-log-to-output": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cypress-log-to-output/-/cypress-log-to-output-1.1.2.tgz",

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@slack/web-api": "^5.8.0",
-    "cypress": "^7.5.0"
+    "cypress": "^7.5.0",
+    "cypress-fail-fast": "^3.1.1"
   }
 }


### PR DESCRIPTION
Signed-off-by: Maggie Chen <magchen@redhat.com>

https://github.com/open-cluster-management/backlog/issues/15544

@fxiang1 This is a draft to solve the canary timeout issue. The plugin will skip the tests when the first test fails and there will be pros and cons.

Pros:
1. If beforeEach test fails, it will skip the rests of the tests so timeout issue will be resolved.
2. In PR test, it will fail after first visible failure, which will reduce our debugging time as oppose to waiting for a 2hr long e2e and found that apps weren't created or env issue

Cons:
1. If multiple issues exist we may not see them all as cypress will fail the first and skip the rest
2. We may need to run cypress test suites individually as if some of them fail to validate, the rest will not run. 