### PR TITLE
Fix undefined search filter for remote argo apps

### DIFF
--- a/src-web/components/Topology/utils/diagram-helpers.js
+++ b/src-web/components/Topology/utils/diagram-helpers.js
@@ -854,6 +854,8 @@ export const createResourceSearchLink = node => {
   //returns search link for resource
   if (nodeType === 'cluster') {
     if (isSearchAvailable()) {
+      const clusterNames = _.get(node, 'specs.clustersNames')
+      const clusterNameStr = clusterNames ? clusterNames.join() : undefined
       result = {
         type: 'link',
         value: {
@@ -861,7 +863,10 @@ export const createResourceSearchLink = node => {
           id: node.id,
           data: {
             action: 'show_search',
-            name: (node.name && R.replace(/ /g, '')(node.name)) || 'undefined', // take out spaces
+            name:
+              (node.name && R.replace(/ /g, '')(node.name)) ||
+              clusterNameStr ||
+              'undefined', // take out spaces
             kind: 'cluster'
           },
           indent: true


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Use `clustersNames` when the cluster node name is an empty string

The generated search query now contains the cluster names instead of undefined:
<img width="1405" alt="image" src="https://user-images.githubusercontent.com/38960034/132052257-08bcbdc1-f0d4-49c1-9f51-bbef52cea97d.png">
