### PR TITLE
Remove validation for empty table state

### DIFF
--- a/tests/cypress/config/index.js
+++ b/tests/cypress/config/index.js
@@ -37,8 +37,10 @@ exports.getConfig = () => {
   let config;
   if (process.env.CYPRESS_TEST_MODE === "e2e") {
     config = fs.readFileSync(path.join(__dirname, "config.e2e.yaml"));
+    secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   } else if (process.env.CYPRESS_TEST_MODE === "smoke") {
     config = fs.readFileSync(path.join(__dirname, "config.smoke.yaml"));
+    secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   } else {
     config = fs.readFileSync(path.join(__dirname, "config.func.yaml"));
     secretConfig = fs.readFileSync(SECRET_FILE_PATH);

--- a/tests/cypress/config/index.js
+++ b/tests/cypress/config/index.js
@@ -35,15 +35,13 @@ const SECRET_FILE_PATH = path.join(
 
 exports.getConfig = () => {
   let config;
+  let secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   if (process.env.CYPRESS_TEST_MODE === "e2e") {
     config = fs.readFileSync(path.join(__dirname, "config.e2e.yaml"));
-    secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   } else if (process.env.CYPRESS_TEST_MODE === "smoke") {
     config = fs.readFileSync(path.join(__dirname, "config.smoke.yaml"));
-    secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   } else {
     config = fs.readFileSync(path.join(__dirname, "config.func.yaml"));
-    secretConfig = fs.readFileSync(SECRET_FILE_PATH);
   }
 
   try {

--- a/tests/cypress/views/common.js
+++ b/tests/cypress/views/common.js
@@ -1253,7 +1253,6 @@ export const validateDefect7696 = name => {
 
 export const navigateApplication = () => {
   cy.visit("/multicloud/applications");
-  cy.get(".pf-c-empty-state", { timeout: 100 * 1000 }).should("not.exist");
   cy
     .get('button[id="actions.create.application"]', { timeout: 100 * 1000 })
     .should("not.be.disabled")

--- a/tests/jest/components/CreateArgoPage/__snapshots__/ArgoApplicationPage.test.js.snap
+++ b/tests/jest/components/CreateArgoPage/__snapshots__/ArgoApplicationPage.test.js.snap
@@ -569,40 +569,43 @@ exports[`ArgoCreationPage creating application set ArgoCreationPage renders corr
                   disabled={false}
                   onClick={[Function]}
                   role={null}
-                  type="button"
+                  type="submit"
                 >
                   Next
                 </button>
                 <button
                   aria-disabled={true}
                   aria-label={null}
-                  className="pf-c-button pf-m-secondary pf-m-aria-disabled"
+                  className="pf-c-button pf-m-secondary pf-m-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-secondary-1"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe={true}
-                  disabled={false}
+                  disabled={true}
                   onClick={[Function]}
-                  onKeyPress={[Function]}
                   role={null}
                   tabIndex={null}
                   type="button"
                 >
                   Back
                 </button>
-                <button
-                  aria-disabled={false}
-                  aria-label={null}
-                  className="pf-c-button pf-m-link"
-                  data-ouia-component-id="OUIA-Generated-Button-link-1"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  role={null}
-                  type="button"
+                <div
+                  className="pf-c-wizard__footer-cancel"
                 >
-                  Cancel
-                </button>
+                  <button
+                    aria-disabled={false}
+                    aria-label={null}
+                    className="pf-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    role={null}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
               </footer>
             </div>
           </div>

--- a/tests/jest/components/CreateArgoPage/__snapshots__/ArgoApplicationPage.test.js.snap
+++ b/tests/jest/components/CreateArgoPage/__snapshots__/ArgoApplicationPage.test.js.snap
@@ -569,43 +569,40 @@ exports[`ArgoCreationPage creating application set ArgoCreationPage renders corr
                   disabled={false}
                   onClick={[Function]}
                   role={null}
-                  type="submit"
+                  type="button"
                 >
                   Next
                 </button>
                 <button
                   aria-disabled={true}
                   aria-label={null}
-                  className="pf-c-button pf-m-secondary pf-m-disabled"
+                  className="pf-c-button pf-m-secondary pf-m-aria-disabled"
                   data-ouia-component-id="OUIA-Generated-Button-secondary-1"
                   data-ouia-component-type="PF4/Button"
                   data-ouia-safe={true}
-                  disabled={true}
+                  disabled={false}
                   onClick={[Function]}
+                  onKeyPress={[Function]}
                   role={null}
                   tabIndex={null}
                   type="button"
                 >
                   Back
                 </button>
-                <div
-                  className="pf-c-wizard__footer-cancel"
+                <button
+                  aria-disabled={false}
+                  aria-label={null}
+                  className="pf-c-button pf-m-link"
+                  data-ouia-component-id="OUIA-Generated-Button-link-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  onClick={[Function]}
+                  role={null}
+                  type="button"
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label={null}
-                    className="pf-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-1"
-                    data-ouia-component-type="PF4/Button"
-                    data-ouia-safe={true}
-                    disabled={false}
-                    onClick={[Function]}
-                    role={null}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
+                  Cancel
+                </button>
               </footer>
             </div>
           </div>
@@ -615,3 +612,4 @@ exports[`ArgoCreationPage creating application set ArgoCreationPage renders corr
   </div>
 </section>
 `;
+


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Related issue - https://github.com/open-cluster-management/backlog/issues/15980 - Canary failure

- Remove a change we made that expect the table to be populated even when no apps are deployed

I think this got past the PR build because we deploy an Argo app before navigating to the apps page but in canary the Argo server test is disabled.

Also fixed the issue found by CICD https://coreos.slack.com/archives/CUEMQ631C/p1631210847039600. Looks like `e2e` and `smoke` were not tested when the `secretConfig` was introduced.