### PR TITLE
Disable type column when search is disabled

### DIFF
--- a/src-web/definitions/hcm-applications.js
+++ b/src-web/definitions/hcm-applications.js
@@ -123,7 +123,8 @@ export default {
       resourceKey: 'type',
       transforms: [cellWidth(20)],
       transformFunction: createTypeCell, // renders the cell on the table
-      textFunction: createTypeText // renders the text used by search bar
+      textFunction: createTypeText, // renders the text used by search bar
+      disabled: () => !isSearchAvailable()
     },
     {
       msgKey: 'table.header.namespace',

--- a/tests/jest/definitions/__snapshots__/index.test.js.snap
+++ b/tests/jest/definitions/__snapshots__/index.test.js.snap
@@ -60,6 +60,7 @@ Object {
       ],
     },
     Object {
+      "disabled": [Function],
       "msgKey": "table.header.type",
       "resourceKey": "type",
       "textFunction": [Function],
@@ -126,6 +127,7 @@ Array [
     ],
   },
   Object {
+    "disabled": [Function],
     "msgKey": "table.header.type",
     "resourceKey": "type",
     "textFunction": [Function],


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/16175

- Disable type column when search is disabled because without search we can't get the subscription data

The UI will not crash when search is disabled:
<img width="1664" alt="image" src="https://user-images.githubusercontent.com/38960034/133487996-8273fe71-6f7b-4d28-b0cd-1255180ca12f.png">
