### PR TITLE
Fix search e2e test failure

### DIFF
--- a/tests/cypress/views/application.js
+++ b/tests/cypress/views/application.js
@@ -579,12 +579,12 @@ export const validateAppTableMenu = (name, resourceTable) => {
   }
   const resourceKey = getResourceKey(name, getNamespace(name), "local-cluster");
   resourceTable.openRowMenu(name, resourceKey);
-  resourceTable.menuClick("search");
+  resourceTable.menuClick("search application");
   cy
     .url()
     .should(
       "include",
-      `multicloud/search?filters={%22textsearch%22:%22name%3A${name}%20namespace%3A${name}-ns%20cluster%3Alocal-cluster%20kind%3Aapplication%20apigroup%3Aapp.k8s.io%20apiversion%3Av1beta1%22}`
+      `search?filters={%22textsearch%22:%22name%3A${name}%20namespace%3A${name}-ns%20cluster%3Alocal-cluster%20kind%3Aapplication%20apigroup%3Aapp.k8s.io%20apiversion%3Av1beta1%22}`
     );
 
   //get back to app page


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/16171

- Set search test to click the correct button

It looks there are two button on the app page now with the `search` text. So the test was clicking on the magnifying glass instead of the row action:
<img width="1487" alt="image" src="https://user-images.githubusercontent.com/38960034/135002114-b5d1a30f-a92c-4d59-9baa-900e97d60e45.png">
