### PR TITLE
Add an additional check for appset kind in the topology overview cards

### DIFF
--- a/src-web/components/common/ResourceOverview/utils.js
+++ b/src-web/components/common/ResourceOverview/utils.js
@@ -249,7 +249,10 @@ export const getAppOverviewCardsData = (
             'specs.raw.metadata.ownerReferences',
             []
           )
-          if (ownerReferences.length > 0) {
+          if (
+            ownerReferences.length > 0 &&
+            ownerReferences[0].kind.toLowerCase() === 'applicationset'
+          ) {
             const res = {
               cluster: node.cluster || LOCAL_HUB_NAME,
               namespace: appNamespace,


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/open-cluster-management/backlog/issues/15192

- Add an additional check for appset kind in the topology overview cards

Currently we only check for the `ownerReference` from the Argo app YAML. I added an additional check for the ownerReference kind to make sure it's an appset