### PR TITLE
Fix node details not closing

### DIFF
--- a/src-web/components/Topology/viewer/DiagramViewer.js
+++ b/src-web/components/Topology/viewer/DiagramViewer.js
@@ -353,10 +353,6 @@ class DiagramViewer extends React.Component {
 
   handleNodeClick = node => {
     currentEvent.stopPropagation()
-    if (node === undefined) {
-      // This fixes clicking in the white space and then switching views messing up
-      return
-    }
 
     // clear any currently selected nodes
     const svg = d3.select(`#${c.DIAGRAM_SVG_ID}`)
@@ -377,7 +373,7 @@ class DiagramViewer extends React.Component {
     }
 
     // else just show details view
-    this.detailsViewUpdate = true
+    this.detailsViewUpdate = node ? true : false
     this.setState({
       selectedNodeId: node ? node.uid : '',
       showDetailsView


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/open-cluster-management/backlog/issues/17002

- Don't set `this.detailsViewUpdate` flag to true when node is undefined